### PR TITLE
0824-carousel-mobile-adjustments

### DIFF
--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -39,7 +39,7 @@ This will be displayed on the homepage. Ideally, you want to highlight key goals
           <div class="splide__list" style="height:auto;">
             {% for slide in site.data.gsacarousel %}
             <div class="splide__slide splide_fix" style="width:auto;padding-right:50px;" role="group" aria-label="Slide about {{slide.heroHeading}}">
-                  <h2 class="hero-heading" style="width:auto;height:auto;overflow-wrap: break-word;" >{{ slide.heroHeading }}</h2>
+                  <h2 class="hero-heading" style="width:auto;height:auto;" >{{ slide.heroHeading }}</h2>
                   <p class="hero-text gsa-text-width" style="width:auto;" >{{ slide.heroText }}</p>
                   <a class="usa-button" style="width: auto;"  href="{{ slide.actionLocation }}" target="{{ slide.actionTarget }}" rel="noopener noreferrer" title="{{ slide.actionButtonText }} {{slide.heroHeading}}" aria-label="{{ slide.actionButtonText }} {{slide.heroHeading}}">{{ slide.actionButtonText }} {{ slide.heroHeading }}</a>            
             </div>

--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -35,13 +35,13 @@ This will be displayed on the homepage. Ideally, you want to highlight key goals
 
       <!-- Splide is initialized on this element so we can use our custom controls above -->
       <div class="splide flex-auto">
-        <div class="splide__track">
-          <div class="splide__list">
+        <div class="splide__track" style="height:auto;">
+          <div class="splide__list" style="height:auto;">
             {% for slide in site.data.gsacarousel %}
-            <div class="splide__slide splide_fix" role="group" aria-label="Slide about {{slide.heroHeading}}">
-                  <h2 class="hero-heading">{{ slide.heroHeading }}</h2>
-                  <p class="hero-text gsa-text-width">{{ slide.heroText }}</p>
-                  <a class="usa-button" href="{{ slide.actionLocation }}" target="{{ slide.actionTarget }}" rel="noopener noreferrer" title="{{ slide.actionButtonText }} {{slide.heroHeading}}" aria-label="{{ slide.actionButtonText }} {{slide.heroHeading}}">{{ slide.actionButtonText }} {{ slide.heroHeading }}</a>            
+            <div class="splide__slide splide_fix" style="width:auto;padding-right:50px;" role="group" aria-label="Slide about {{slide.heroHeading}}">
+                  <h2 class="hero-heading" style="width:auto;height:auto;overflow-wrap: break-word;" >{{ slide.heroHeading }}</h2>
+                  <p class="hero-text gsa-text-width" style="width:auto;" >{{ slide.heroText }}</p>
+                  <a class="usa-button" style="width: auto;"  href="{{ slide.actionLocation }}" target="{{ slide.actionTarget }}" rel="noopener noreferrer" title="{{ slide.actionButtonText }} {{slide.heroHeading}}" aria-label="{{ slide.actionButtonText }} {{slide.heroHeading}}">{{ slide.actionButtonText }} {{ slide.heroHeading }}</a>            
             </div>
             {% endfor %}
 

--- a/assets/css/index.scss
+++ b/assets/css/index.scss
@@ -93,11 +93,16 @@
 .usa-hero {
   //background-image: asset_url("new-header-graphic.png");
   background-image: url("{{site.baseurl}}/assets/images/new-background-30-fade.png");
-  //background-image: asset_url("hero-image2-blur.png");
   background-position: 50%;
   background-size: cover;
-  height: 380px;
+  // height: 380px;
+  height: auto;
   margin: 0px;
+}
+
+// To make both sides of a slide the same. see: _include/hero.html for element styles
+.splide__slide {
+  padding-left: 50px;
 }
 
 // Back to top button, displays in lower right corner after 500px of scroll.
@@ -132,8 +137,8 @@
 
 // Responsive Hero for IDManagement
 .gsa-responsive-hero {
-  height: auto;
-  min-width: 300px; 
+  height:auto;
+  min-width: 220px; 
 }
 
 // Hero text length shortener-er 
@@ -142,13 +147,11 @@
   width: auto;
 }
 
-// .gsa-no-dec {
-//   text-decoration: none;
-// }
-
+// GSA Slide positions and height: also see: gsa-responsive-hero
 .gsa-slide {
   position: relative;
-  height: 380px;
+  // height: 380px;
+  height:auto;
   display: flex;
   align-items: center;
 }
@@ -188,7 +191,7 @@
 }
 // Fix problem with carousel's first slide not displaying at same width as proceeding slides and added tinting to cover busy images that are being selected as headers. 
 .gsa-carousel-fix {
-  width: 100%;
+  width: auto;
   padding: 20px;
  //background-color: rgba(#000000, 0.7);
 }

--- a/assets/css/index.scss
+++ b/assets/css/index.scss
@@ -328,3 +328,24 @@
     display: block;
   }
 }
+
+@media (max-width: 640px) {
+  .paginate-link {
+    display: none;
+  }
+  .paginate-button {
+    display: block;
+  }
+  // Mobile Carousel adjustments
+  .hero-heading {
+    font-size: 2rem;
+  }
+  
+  .hero-text {
+    font-size: 1rem;
+  }
+  
+  .usa-button {
+    font-size: 0.9rem;
+  }
+}


### PR DESCRIPTION
Fix for #454
 
Changes:
- made the text area and button text flexible
- added a media-query for screens below 640px, nothing is off-screen now for mobile. 
- fixed padding on the right side of slides in the carousel, making it look more centered.
- made several containers used in the construction of the carousel adjustable instead of fixed.

@SuGhadiali 