### PR TITLE
1026 fpki system notification

### DIFF
--- a/_data/fpkinotifications.yml
+++ b/_data/fpkinotifications.yml
@@ -26,6 +26,21 @@
 # ee_cdp_uri:
 # ee_ocsp_uri:
 
+- notice_date: October 25, 2023
+  change_type: CA Certificate Issuance
+  system: FPKI Trust Infrastructure - Federal Common Policy CA G2
+  change_description: The Federal Common Policy CA G2 intends to issue a new cross certificate to the U.S. Department of State AD Root CA between 11/08/2023 and 11/15/2023
+  contact: fpki dash help at gsa dot gov
+  ca_certificate_hash: N/A
+  ca_certificate_issuer: CN=Federal Common Policy CA G2, OU=FPKI, O=U.S. Government, C=US
+  ca_certificate_subject: CN=U.S. Department of State AD Root CA, CN=AIA, CN=Public Key Services, CN=Services, CN=Configuration, DC=state, DC=sbu
+  cdp_uri: http://repo.fpki.gov/fcpca/fcpcag2.crl
+  aia_uri: http://repo.fpki.gov/fcpca/caCertsIssuedTofcpcag2.p7c
+  sia_uri: http://crls.pki.state.gov/SIA/CertsIssuedByADRootCA.p7c
+  ocsp_uri: N/A
+  ee_cdp_uri: N/A
+  ee_ocsp_uri: N/A
+
 - notice_date: October 20, 2023
   change_type: CA Certificate Issuance
   system: FPKI Trust Infrastructure - Federal Bridge CA G4

--- a/_data/fpkinotifications.yml
+++ b/_data/fpkinotifications.yml
@@ -115,21 +115,6 @@
   ocsp_uri: N/A
   ee_cdp_uri: http://ipki.uspto.gov/IPKI/CRLs/CombinedCRL4.crl
   ee_ocsp_uri: N/A
-
- - notice_date: October 6, 2023
-  change_type: Intent to Issue CA Certificate
-  system: FPKI Trust Infrastructure - Federal Bridge CA G4
-  change_description: The Federal Bridge CA G4 intends to issue a new cross certificate to the DirectTrust Identity Bridge CA between 10/23/2023 and 10/30/2023
-  contact: fpki dash help at gsa dot gov
-  ca_certificate_hash: N/A
-  ca_certificate_issuer: CN=Federal Bridge CA G4, OU=FPKI, O=U.S. Government, C=US
-  ca_certificate_subject: CN=DirectTrust Identity Bridge CA, OU=Certification Authorities, O=DirectTrust.org, inc., C=US
-  cdp_uri: http://repo.fpki.gov/bridge/fbcag4.crl
-  aia_uri: http://repo.fpki.gov/bridge/caCertsIssuedTofbcag4.p7c
-  sia_uri: http://ipki.uspto.gov/IPKI/Certs/IPKICACerts.p7c
-  ocsp_uri: N/A
-  ee_cdp_uri: N/A
-  ee_ocsp_uri: N/A 
    
 - notice_date: August 29, 2023
   change_type: CA Certificate Issuance

--- a/_data/fpkinotifications.yml
+++ b/_data/fpkinotifications.yml
@@ -27,7 +27,7 @@
 # ee_ocsp_uri:
 
 - notice_date: October 25, 2023
-  change_type: CA Certificate Issuance
+  change_type: Intent to Issue a CA Certificate
   system: FPKI Trust Infrastructure - Federal Common Policy CA G2
   change_description: The Federal Common Policy CA G2 intends to issue a new cross certificate to the U.S. Department of State AD Root CA between 11/08/2023 and 11/15/2023
   contact: fpki dash help at gsa dot gov

--- a/_data/fpkinotifications.yml
+++ b/_data/fpkinotifications.yml
@@ -26,6 +26,21 @@
 # ee_cdp_uri:
 # ee_ocsp_uri:
 
+- notice_date: October 26, 2023
+  change_type: CA Certificate Issuance
+  system: FPKI Trust Infrastructure - Federal Bridge CA G4
+  change_description: The Federal Bridge CA G4 issued a new cross certificate to the DirectTrust Identity Bridge CA
+  contact: fpki dash help at gsa dot gov
+  ca_certificate_hash: ddd7246c86b2e0a3ac2fc7a7dbb7430b935eba2f
+  ca_certificate_issuer: CN=Federal Bridge CA G4, OU=FPKI, O=U.S. Government, C=US
+  ca_certificate_subject: CN=DirectTrust Identity Bridge CA, OU=Certification Authorities, O=DirectTrust.org, inc., C=US
+  cdp_uri: http://repo.fpki.gov/bridge/fbcag4.crl
+  aia_uri: http://repo.fpki.gov/bridge/caCertsIssuedTofbcag4.p7c
+  sia_uri: http://ipki.uspto.gov/IPKI/Certs/IPKICACerts.p7c
+  ocsp_uri: N/A
+  ee_cdp_uri: N/A
+  ee_ocsp_uri: N/A
+
 - notice_date: October 25, 2023
   change_type: Intent to Issue a CA Certificate
   system: FPKI Trust Infrastructure - Federal Common Policy CA G2
@@ -100,6 +115,21 @@
   ocsp_uri: N/A
   ee_cdp_uri: http://ipki.uspto.gov/IPKI/CRLs/CombinedCRL4.crl
   ee_ocsp_uri: N/A
+
+ - notice_date: October 6, 2023
+  change_type: Intent to Issue CA Certificate
+  system: FPKI Trust Infrastructure - Federal Bridge CA G4
+  change_description: The Federal Bridge CA G4 intends to issue a new cross certificate to the DirectTrust Identity Bridge CA between 10/23/2023 and 10/30/2023
+  contact: fpki dash help at gsa dot gov
+  ca_certificate_hash: N/A
+  ca_certificate_issuer: CN=Federal Bridge CA G4, OU=FPKI, O=U.S. Government, C=US
+  ca_certificate_subject: CN=DirectTrust Identity Bridge CA, OU=Certification Authorities, O=DirectTrust.org, inc., C=US
+  cdp_uri: http://repo.fpki.gov/bridge/fbcag4.crl
+  aia_uri: http://repo.fpki.gov/bridge/caCertsIssuedTofbcag4.p7c
+  sia_uri: http://ipki.uspto.gov/IPKI/Certs/IPKICACerts.p7c
+  ocsp_uri: N/A
+  ee_cdp_uri: N/A
+  ee_ocsp_uri: N/A 
    
 - notice_date: August 29, 2023
   change_type: CA Certificate Issuance

--- a/_implement/fpki_notifications.md
+++ b/_implement/fpki_notifications.md
@@ -641,7 +641,7 @@ These CA certificates have issued PIV, PIV-I and/or Derived PIV authentication c
 - Validity: December 10, 2014 to November 11, 2024
 - SHA-1 Hash: dc5b590800765864587902af983c21a7209be320
 - CRL DP: [http://onsite-crl.pki.digicert.com/USDepartmentofTransportationFAAPIVG4/LatestCRL.crl](http://onsite-crl.pki.digicert.com/USDepartmentofTransportationFAAPIVG4/LatestCRL.crl){:target="_blank"}{:rel="noopener noreferrer"}
-- 
+
 #### USPTO INTR CA1
 - Subject: CN = USPTO_INTR_CA1, CN = AIA, CN = Public Key Services, CN = Services, CN = Configuration, DC = uspto, DC = gov
 - Issuer: CN = USPTO_INTR_CA1, CN = AIA, CN = Public Key Services, CN = Services, CN = Configuration, DC = uspto, DC = gov

--- a/_implement/fpki_notifications.md
+++ b/_implement/fpki_notifications.md
@@ -400,10 +400,10 @@ These CA certificates are actively issuing PIV , PIV-I and/or Derived PIV authen
 #### USPTO INTR CA1
 - Subject: CN = USPTO_INTR_CA1, CN = AIA, CN = Public Key Services, CN = Services, CN = Configuration, DC = uspto, DC = gov
 - Issuer: CN = USPTO_INTR_CA1, CN = AIA, CN = Public Key Services, CN = Services, CN = Configuration, DC = uspto, DC = gov
-- Serial #: 4c296f47
-- Validity: April 7, 2018 to December 7, 2029
-- SHA-1 Hash: bc67b9e65ee05c3742c27187259ded3e6112a587
-- CRL DP: [http://ipki.uspto.gov/IPKI/CRLs/CombinedCRL3.crl](http://ipki.uspto.gov/IPKI/CRLs/CombinedCRL3.crl){:target="_blank"}{:rel="noopener noreferrer"}
+- Serial #: 162a8a8ddfb79fa3460a7a92765926fb108fd6aa
+- Validity: October 19, 2023 to October 19, 2026
+- SHA-1 Hash: 02ecec9eb7229055c57caeaade6f1ae056fb4327
+- CRL DP: [http://ipki.uspto.gov/IPKI/CRLs/CombinedCRL4.crl](http://ipki.uspto.gov/IPKI/CRLs/CombinedCRL4.crl){:target="_blank"}{:rel="noopener noreferrer"}
 
 #### Veterans Affairs User CA B1
 - Subject: CN = Veterans Affairs User CA B1, OU = PKI, OU = Services, DC = va, DC = gov
@@ -641,6 +641,14 @@ These CA certificates have issued PIV, PIV-I and/or Derived PIV authentication c
 - Validity: December 10, 2014 to November 11, 2024
 - SHA-1 Hash: dc5b590800765864587902af983c21a7209be320
 - CRL DP: [http://onsite-crl.pki.digicert.com/USDepartmentofTransportationFAAPIVG4/LatestCRL.crl](http://onsite-crl.pki.digicert.com/USDepartmentofTransportationFAAPIVG4/LatestCRL.crl){:target="_blank"}{:rel="noopener noreferrer"}
+- 
+#### USPTO INTR CA1
+- Subject: CN = USPTO_INTR_CA1, CN = AIA, CN = Public Key Services, CN = Services, CN = Configuration, DC = uspto, DC = gov
+- Issuer: CN = USPTO_INTR_CA1, CN = AIA, CN = Public Key Services, CN = Services, CN = Configuration, DC = uspto, DC = gov
+- Serial #: 4c296f47
+- Validity: April 7, 2018 to December 7, 2029
+- SHA-1 Hash: bc67b9e65ee05c3742c27187259ded3e6112a587
+- CRL DP: [http://ipki.uspto.gov/IPKI/CRLs/CombinedCRL3.crl](http://ipki.uspto.gov/IPKI/CRLs/CombinedCRL3.crl){:target="_blank"}{:rel="noopener noreferrer"}
 
 ## FPKI System Changes and Notifications
 


### PR DESCRIPTION
Adds two new notifications for a CA certificate issuance from FBCA (DirectTrust) and an intended issuance from FCPCA (DoS), additionally updates PIV issuing page to include new USPTO PIV issuing CA information.

Closes #641 
Closes #642 
Closes #644 