### PR TITLE
1023 cpct fpkilint announcement

### DIFF
--- a/_data/fpkiannouncements.yml
+++ b/_data/fpkiannouncements.yml
@@ -1,5 +1,11 @@
 ## FPKI announcements
 
+- title: CPCT Tool Update:<br>New Certificate Profiles
+  pubDate: October 18, 2023
+  url: /implement/announcements/cpct-profile-update/
+  description: The Certificate Profiles used by the CPCT Tool have updated to Common SSP (v2.5) and FBCA (v3.2). CPCT Tool update required.
+  status: Active
+
 - title: Public Trust PKI Certificate Policy
   pubDate: February 10, 2023
   url: /implement/announcements/PT-TLS-CP/

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -106,7 +106,7 @@ playbooks:
 # Announcements moved to internal page see: /fpki/notifications/#fpki-announcements
 # Added 'Back to FPKI Notifications' to help users return to notifications 
 fpkiannouncements:
-  - text: Back to FPKI Notifications
+  - text: Back to FPKI Announcements
     href: /fpki/notifications 
 #   - text: Public Trust TLS PKI CP
 #     href: /fpki/announcements/PT-TLS-CP/

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -106,7 +106,7 @@ playbooks:
 # Announcements moved to internal page see: /fpki/notifications/#fpki-announcements
 # Added 'Back to FPKI Notifications' to help users return to notifications 
 fpkiannouncements:
-  - text: Back to<br> FPKI Announcements
+  - text: Back to FPKI Announcements
     href: /fpki/notifications 
 #   - text: Public Trust TLS PKI CP
 #     href: /fpki/announcements/PT-TLS-CP/

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -103,10 +103,11 @@ playbooks:
   - text: Windows Hello for Business Playbook
     href: /playbooks/whfb/
 
-# Announcements moved to internal page see: /fpki/notifications/#fpki-announcements  
-# fpkiannouncements:
-#   - text: Back to FPKI Page
-#     href: /fpki/notifications
+# Announcements moved to internal page see: /fpki/notifications/#fpki-announcements
+# Added 'Back to FPKI Notifications' to help users return to notifications 
+fpkiannouncements:
+  - text: Back to FPKI Notifications
+    href: /fpki/notifications 
 #   - text: Public Trust TLS PKI CP
 #     href: /fpki/announcements/PT-TLS-CP/
 #   - text: CPCT Tool Update

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -106,7 +106,7 @@ playbooks:
 # Announcements moved to internal page see: /fpki/notifications/#fpki-announcements
 # Added 'Back to FPKI Notifications' to help users return to notifications 
 fpkiannouncements:
-  - text: Back to FPKI Announcements
+  - text: Back to<br> FPKI Announcements
     href: /fpki/notifications 
 #   - text: Public Trust TLS PKI CP
 #     href: /fpki/announcements/PT-TLS-CP/

--- a/_implement/announcements/14_cpct_profile_update.md
+++ b/_implement/announcements/14_cpct_profile_update.md
@@ -46,7 +46,7 @@ In order to update the CPCT tool you will need to remove any existing instances 
 - The CPCT Tool (CPCT) is a Dockerized version of the Certificate Profile Conformance Tool (CPCT) you install on your computer via Docker Desktop. This is GSA's recommended way to install and use the CPCT Tool
 - The Certificate Profile Conformance Tool (CPCT) is the original code of the web hosted version of the tool, which was removed from service on October 10, 2022.
 
-For more information see: [CPCT Tool transition from Cloud.gov](/implement/announcements/cpct-transition/){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"}
+For more information see: [CPCT Tool transition from Cloud.gov]({{site.url}}/implement/announcements/cpct-transition/){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"}
 
 If you have any questions regarding this action please contact:
 fpki dash help at gsa dot gov

--- a/_implement/announcements/14_cpct_profile_update.md
+++ b/_implement/announcements/14_cpct_profile_update.md
@@ -1,4 +1,5 @@
 ---
+
 layout: page
 title: CPCT Tool Update:<br>New Certificate Profiles
 pubDate: 10/18/2023

--- a/_implement/announcements/14_cpct_profile_update.md
+++ b/_implement/announcements/14_cpct_profile_update.md
@@ -1,0 +1,52 @@
+---
+layout: page
+title: CPCT Tool Update:<br>New Certificate Profiles
+pubDate: 10/18/2023
+removeDate: 10/18/2026
+collection: implement
+permalink: /implement/announcements/cpct-profile-update/
+description: The Certificate Profiles used by the CPCT Tool have updated to Common SSP (v2.5) and FBCA (v3.2). CPCT Tool update required.
+category: Active
+sticky_sidenav: true
+sidenav: fpkiannouncements
+      
+---
+
+In order to keep this tool up-to-date and using the latest Certificate Profiles, users are required to update any local copies of the CPCT Tool they have previously installed to the latest release of the CPCT Tool (CPCT). First, removing the old version, then download and install the latest release version: see the download link below.
+
+- [Download the latest CPCT Tool release](https://github.com/GSA/cpct-tool/releases){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"}
+
+New Certificate Profile updates include:
+
+- (NEW) Common SSP (v2.5) Profiles
+- (NEW) FBCA (v3.2) Profiles
+- (NEW) Merging of the PIV-I Profiles into the FBCA (v3.2) Profiles.
+- PIV-I Profiles v1.2 and v1.3 remain unchanged for legacy and backwards compatibility.
+
+For more information about Profile changes, see: [changelog](https://github.com/GSA/fpkilint/blob/dev/changelog.md){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"}.
+
+## CPCT Update Instructions
+
+In order to update the CPCT tool you will need to remove any existing instances of the Docker image, and subsequently download the latest release and run the installer. Please find the following links with more detailed instructions on this update process:
+
+1. [Remove the current Docker image](https://github.com/GSA/cpct-tool/wiki/Removing-Docker-Images){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"}
+2. [Update the CPCT Tool](https://github.com/GSA/cpct-tool/wiki/Updating-the-CPCT-Tool){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"}
+3. [Installing the CPCT Tool](https://github.com/GSA/cpct-tool/wiki/Installing-the-CPCT-Tool){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"}
+
+## Additional Resources
+
+- [CPCT Tool release page](https://github.com/GSA/cpct-tool/releases){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"}
+- [CPCT Tool Wiki](https://github.com/GSA/cpct-tool/wiki){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"}
+- [Submit a CPCT Tool issue](https://github.com/GSA/cpct-tool/issues){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"}
+- [Certificate Profile Conformance Tool (CPCT) GitHub repo](https://github.com/GSA/fpkilint){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"}
+- [Submit a Certificate Profile Conformance Tool (CPCT) issue](https://github.com/GSA/fpkilint/issues){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"}
+
+**What's the difference between the CPCT Tool (CPCT) and the Certificate Profile Conformance Tool (CPCT)?**
+
+- The CPCT Tool (CPCT) is a Dockerized version of the Certificate Profile Conformance Tool (CPCT) you install on your computer via Docker Desktop. This is GSA's recommended way to install and use the CPCT Tool
+- The Certificate Profile Conformance Tool (CPCT) is the original code of the web hosted version of the tool, which was removed from service on October 10, 2022.
+
+For more information see: [CPCT Tool transition from Cloud.gov](){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"}
+
+If you have any questions regarding this action please contact:
+fpki dash help at gsa dot gov

--- a/_implement/announcements/14_cpct_profile_update.md
+++ b/_implement/announcements/14_cpct_profile_update.md
@@ -46,7 +46,7 @@ In order to update the CPCT tool you will need to remove any existing instances 
 - The CPCT Tool (CPCT) is a Dockerized version of the Certificate Profile Conformance Tool (CPCT) you install on your computer via Docker Desktop. This is GSA's recommended way to install and use the CPCT Tool
 - The Certificate Profile Conformance Tool (CPCT) is the original code of the web hosted version of the tool, which was removed from service on October 10, 2022.
 
-For more information see: [CPCT Tool transition from Cloud.gov](){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"}
+For more information see: [CPCT Tool transition from Cloud.gov](/implement/announcements/cpct-transition/){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"}
 
 If you have any questions regarding this action please contact:
 fpki dash help at gsa dot gov

--- a/_implement/announcements/14_cpct_profile_update.md
+++ b/_implement/announcements/14_cpct_profile_update.md
@@ -12,7 +12,7 @@ sidenav: fpkiannouncements
       
 ---
 
-In order to keep this tool up-to-date and using the latest Certificate Profiles, users are required to update any local copies of the CPCT Tool they have previously installed to the latest release of the CPCT Tool (CPCT). First, removing the old version, then download and install the latest release version: see the download link below.
+In order to keep this tool up-to-date and using the latest Certificate Profiles, users are required to update any local copies of the CPCT Tool they have previously installed to the latest release of the CPCT Tool (CPCT). First, by removing the old version, then downloading and installing the latest release version: see the download link below.
 
 - [Download the latest CPCT Tool release](https://github.com/GSA/cpct-tool/releases){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"}
 


### PR DESCRIPTION
# CPCT Tool and Profiles Update Announcement
- Announcement of CPCT Tool and New Profiles update

Certificate Updates:
- Certificate Profile changes:
- Common SSP v2.5
- FPKI/Federal Bridge v3.2
- PIV-I (merged into FBCA v3.2)
- PIV-I 1.2 and 1.3 (legacy)

Additional Actions: 
- Updated Profiles in the Certificate Profile Conformance Tool (CPCT) (fpkilint repo) updated and pushed
- Updated CPCT Tool Release updated to 2.0.0
- Updated CPCT Tool Wiki Documentation updated

This should update cpct tool's docer image to use the new profiles on the `fpkilint` repo, advance the version of `cpct tool release` to 2.0, and send required `notice` to users. 

@SuGhadiali @TheInfinityBeyonder @rsherwood-gsa 

