### PR TITLE
0227-fpki-system-notification-update

### DIFF
--- a/_implement/fpki_notifications.md
+++ b/_implement/fpki_notifications.md
@@ -745,9 +745,9 @@ Subject:  FPKI System Notification - System Name
       type="button"
       class="usa-accordion__button"
       aria-expanded="false"
-      aria-controls="n-a2">2023</button>
+      aria-controls="n-a6">2023</button>
   </h4>
-  <div id="n-a2" class="usa-accordion__content usa-prose">
+  <div id="n-a6" class="usa-accordion__content usa-prose">
    <div class="usa-width-one-whole">
       {% for notification in site.data.fpkinotifications %}
         {% assign nnd = notification.notice_date | split:" " %}
@@ -782,9 +782,9 @@ Subject:  FPKI System Notification - System Name
       type="button"
       class="usa-accordion__button"
       aria-expanded="false"
-      aria-controls="n-a2">2022</button>
+      aria-controls="n-a5">2022</button>
   </h4>
-  <div id="n-a2" class="usa-accordion__content usa-prose">
+  <div id="n-a5" class="usa-accordion__content usa-prose">
    <div class="usa-width-one-whole">
       {% for notification in site.data.fpkinotifications %}
         {% assign nnd = notification.notice_date | split:" " %}

--- a/_implement/fpki_notifications.md
+++ b/_implement/fpki_notifications.md
@@ -707,10 +707,48 @@ Subject:  FPKI System Notification - System Name
       type="button"
       class="usa-accordion__button"
       aria-expanded="true"
-      aria-controls="n-a1">2023 (Current)</button>
+      aria-controls="n-a1">2024 (Current)</button>
   </h4>
   <div id="n-a1" class="usa-accordion__content usa-prose">
     <div class="usa-width-one-whole">
+      {% for notification in site.data.fpkinotifications %}
+        {% assign nnd = notification.notice_date | split:" " %}
+        {% if nnd.last == '2024' %}
+        <ul class="usa-unstyled-list">
+          <hr>
+          <li><strong>Notice Date: </strong>{{ notification.notice_date }} </li>
+          <li><strong>System:</strong> {{ notification.system }} </li>
+          <li><strong>Type:</strong> {{ notification.change_type }} </li>
+          <li><strong>Change Description:</strong> {{ notification.change_description }} </li>
+          <li><strong>Contact:</strong> {{ notification.contact }}</li>
+          <li><strong>Certificate Issuer:</strong> {{ notification.ca_certificate_issuer }}</li>
+          <li><strong>Certificate Subject:</strong> {{ notification.ca_certificate_subject }}</li>
+          <li><strong>Certificate SHA1 Hash:</strong> {{ notification.ca_certificate_hash }}</li>
+          <li><strong>Certificate Revocation List:</strong> {{ notification.cdp_uri }}</li>
+          <li><strong>Certificate Bundle (AIA):</strong> {{ notification.aia_uri }}</li>
+          <li><strong>Certificate Bundle (SIA):</strong> {{ notification.sia_uri }}</li>
+          <li><strong>OCSP:</strong> {{ notification.ocsp_uri }}</li>
+          <li><strong>EE CRL DP:</strong> {{ notification.ee_cdp_uri }}</li>
+          <li><strong>EE OCSP:</strong> {{ notification.ee_ocsp_uri }}</li>
+        </ul>
+        {% else %}
+          {% continue %}
+        {% endif %}
+      {% endfor %}
+    </div>
+  </div>
+  <!-- end of current notifications -->
+    <hr>
+  <!-- Start of 2023 notifications -->
+  <h4 class="usa-accordion__heading">
+    <button
+      type="button"
+      class="usa-accordion__button"
+      aria-expanded="false"
+      aria-controls="n-a2">2023</button>
+  </h4>
+  <div id="n-a2" class="usa-accordion__content usa-prose">
+   <div class="usa-width-one-whole">
       {% for notification in site.data.fpkinotifications %}
         {% assign nnd = notification.notice_date | split:" " %}
         {% if nnd.last == '2023' %}
@@ -737,8 +775,7 @@ Subject:  FPKI System Notification - System Name
       {% endfor %}
     </div>
   </div>
-  <!-- end of current notifications -->
-    <hr>
+  <!-- end of 2023 notifications -->
   <!-- Start of 2022 notifications -->
   <h4 class="usa-accordion__heading">
     <button


### PR DESCRIPTION
Closes #815 

**Update:**
- Updated `FPKI Listing` under `Notifications` section of: [/fpki/notifications/#notifications](https://www.idmanagement.gov/fpki/notifications/#notifications)
- Added markdown accordion code to display FPKI listings for `2024`.
- Updated accordion markdown component ids to prevent component confects. 
- Updated Heading to `2024`

> **Note:** This update id s once a year task, since the code accordion markdown code was broken up to provide more granular control over what notifications display in the `Notifications` section. 

@SuGhadiali 
@dproudGSA 
@rsherwood-gsa 
@maxwellfunk 
@JBPayne007 
@TheInfinityBeyonder 
@KonradMiles 