### PR TITLE
USWD 3.8.0 update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "federalist-uswds-jekyll",
       "version": "1.3.0",
       "dependencies": {
-        "@uswds/uswds": "3.7.1"
+        "@uswds/uswds": "3.8.0"
       },
       "devDependencies": {
         "pa11y-ci": "^2.4.0",
@@ -16,9 +16,9 @@
       }
     },
     "node_modules/@uswds/uswds": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.7.1.tgz",
-      "integrity": "sha512-32u2S50bf5dwIujebqL+f1Jgx2rmRrpxcaccSZzdo3Qv9HaDUdcmeavlrxHqN30edHc7p8kRPjvjevOmOJKB7w==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@uswds/uswds/-/uswds-3.8.0.tgz",
+      "integrity": "sha512-rMwCXe/u4HGkfskvS1Iuabapi/EXku3ChaIFW7y/dUhc7R1TXQhbbfp8YXEjmXPF0yqJnv9T08WPgS0fQqWZ8w==",
       "dependencies": {
         "classlist-polyfill": "1.2.0",
         "object-assign": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "pa11y-ci:sitemap": "pa11y-ci --sitemap http://localhost:4000/sitemap.xml --sitemap-exclude \"/*.pdf\""
   },
   "dependencies": {
-    "@uswds/uswds": "3.7.1"
+    "@uswds/uswds": "3.8.0"
   },
   "devDependencies": {
     "pa11y-ci": "^2.4.0",


### PR DESCRIPTION
Closes #903 

## New Version: USWDS v3.8.0
A new version of the [U.S. Web Design System (USWDS)](https://designsystem.digital.gov/how-to-use-uswds/) released. 🥇 

Requesting a review period for more 👀 to review:

- Updated to the latest version `v3.8.0` from the current version `v3.7.1`. 🔧 
- Updated package.json. 👍 
- Updated package-lock.json. 👍 
- Tested on local and [preview site](https://federalist-cf03235f-a054-4178-aafb-4e1e61e0d42c.sites.pages.cloud.gov/preview/gsa/idmanagement.gov/0502-uswds-3-8-0-update/) with no errors. 👍 
- Update impact expected: little to none. 🛠️ 
- Information on recent updates can be found [here](https://github.com/uswds/uswds?tab=readme-ov-file#recent-updates). ☕ 

@SuGhadiali 
@TheInfinityBeyonder
@rsherwood-gsa  
@JBPayne007 
@KonradMiles 