### PR TITLE
0612-nist-broken-link-update

### DIFF
--- a/_playbooks/playbook-altauthn.md
+++ b/_playbooks/playbook-altauthn.md
@@ -70,7 +70,7 @@ In collaboration with the FIDO2 CoA members, the FIDO Alliance also published a 
   </div>
 </div>
 
-# Executive Summary
+## Executive Summary
 
 This Phishing-Resistant Authenticator Playbook is a practical guide to help agencies understand and implement multiple types of phishing-resistant authentication. Office of Management and Budget Memo 22-09, Federal Zero Trust Strategy, provides ongoing guidance for modernizing Homeland Security Presidential Directive 12 for logical IT access. M-22-09 outlines that **Agencies must require their users, including employees, contractors, and other workforce users such as mission and business partners, to use a phishing-resistant method to access agency resources.** This includes removing any authentication option that fails to resist credential-based attacks, such as phishing, push bombing, SIM swap, and adversary-in-the-middle One-Time PIN (OTP) interception. These phishable and replayable authentication options used by most agencies include SMS or voice one-time pins (OTP), Time-based OTP (TOTP) for mobile, email, and tokens, or mobile application push notifications. Only phishing-resistant authentication options reduce an agency's risk associated with credential-based attacks, often leading to account compromise and network/cloud lateral movement. 
 

--- a/_redirects/manage-redirect.md
+++ b/_redirects/manage-redirect.md
@@ -1,0 +1,16 @@
+---
+
+# Redirect
+layout: page
+# Title of destination page
+title: Program Managers
+# Old link to respond to
+permalink: /manage/
+# New destination to send visitor to
+redirect: https://www.idmanagement.gov/program-managers/
+delaytime: 0
+memo: redirect for old /manage/ link, mostly on NIST webpages.
+
+---
+
+{% include redirect.html %}

--- a/_redirects/template-redirect.md
+++ b/_redirects/template-redirect.md
@@ -6,7 +6,7 @@ title: # Title of the destination page
 permalink: # the address portion of the page requested for exp: /fpki-page/ or /fpki-page/#header-on-page
 redirect: # full url (including https://) of destination page. [can be exernal]
 delaytime: 0 # amount of time to wait before sending to destination page. (Default: 0) 
-memo: # note to remember my this redirect is needed. 
+memo: # note to remember why this redirect is needed. 
 
 ---
 


### PR DESCRIPTION
Closes #986 

Added Redirect to website: 

**Old  Resource:** 
  - Title: Managing Federal Identity Programs
  - https://www.idmanagement.gov/manage/

**New Resource:** 
  - Title: Program Managers
  - New Address: https://www.idmanagement.gov/program-managers/

> Webmaster at NIST also notified, details in issue: #986 

@SuGhadiali 
@TheInfinityBeyonder 

