### PR TITLE
0912-alert-markdown-support

### DIFF
--- a/_implement/scl-windows.md
+++ b/_implement/scl-windows.md
@@ -570,7 +570,7 @@ To grant a user access, based on the type of authenticator used, you can use a W
     <h4 class="usa-alert__heading">Do not uses AMA to provide privileged access</h4>
     <p class="usa-alert__text">
       Privileged users should not rely on single sign-on and should always use the highest assurance credential. Their account should be separate and distinct from their normal user account. See the 
-      <a class="usa-link" href="{{site.baseurl}}/playbooks/pam/" target="_blank" rel="noopener noreferrer"}>Privileged Identity Playbook</a>
+      <a class="usa-link" href="{{site.baseurl}}/playbooks/pam/" target="_blank" rel="noopener noreferrer">Privileged Identity Playbook</a>
       for best practices in reducing risk associated with privileged accounts and access.
     </p>
   </div>

--- a/_includes/alert-error.html
+++ b/_includes/alert-error.html
@@ -1,6 +1,6 @@
 <div class="usa-alert usa-alert--error" role="alert">
   <div class="usa-alert__body">
     <h3 class="usa-alert__heading">{{include.heading}}</h3>
-    <p class="usa-alert__text">{{include.content}}</p>
+    <p class="usa-alert__text">{{include.content | markdownify}}</p>
   </div>
 </div>

--- a/_includes/alert-info.html
+++ b/_includes/alert-info.html
@@ -1,6 +1,6 @@
 <div class="usa-alert usa-alert--info">
   <div class="usa-alert__body">
     <h3 class="usa-alert__heading">{{include.heading}}</h3>
-    <p class="usa-alert__text">{{include.content | markdownify }}</p>
+    <p class="usa-alert__text">{{include.content | markdownify}}</p>
   </div>
 </div>

--- a/_includes/alert-no-icon-success.html
+++ b/_includes/alert-no-icon-success.html
@@ -1,5 +1,5 @@
 <div class="usa-alert usa-alert--success usa-alert--no-icon" >
   <div class="usa-alert__body">
-    <p class="usa-alert__text">{{include.content}}</p>
+    <p class="usa-alert__text">{{include.content | markdownify}}</p>
   </div>
 </div>

--- a/_includes/alert-no-icon.html
+++ b/_includes/alert-no-icon.html
@@ -1,5 +1,5 @@
 <div class="usa-alert usa-alert--info usa-alert--no-icon" >
   <div class="usa-alert__body">
-    <p class="usa-alert__text">{{include.content}}</p>
+    <p class="usa-alert__text">{{include.content | markdownify}}</p>
   </div>
 </div>

--- a/_includes/alert-slim.html
+++ b/_includes/alert-slim.html
@@ -2,6 +2,6 @@
 
 <div class="usa-alert usa-alert--info usa-alert--slim" >
   <div class="usa-alert__body">
-    <p class="usa-alert__text">{{include.content}}</p>
+    <p class="usa-alert__text">{{include.content | markdownify}}</p>
   </div>
 </div>

--- a/_includes/alert-success.html
+++ b/_includes/alert-success.html
@@ -1,6 +1,6 @@
 <div class="usa-alert usa-alert--success">
   <div class="usa-alert__body">
     <h3 class="usa-alert__heading">{{include.heading}}</h3>
-    <p class="usa-alert__text">{{include.content | markdownify }}</p>
+    <p class="usa-alert__text">{{include.content | markdownify}}</p>
   </div>
 </div>

--- a/_includes/alert-warning.html
+++ b/_includes/alert-warning.html
@@ -1,6 +1,6 @@
 <div class="usa-alert usa-alert--warning">
   <div class="usa-alert__body">
     <h3 class="usa-alert__heading">{{include.heading}}</h3>
-    <p class="usa-alert__text">{{include.content | markdownify }}</p>
+    <p class="usa-alert__text">{{include.content | markdownify}}</p>
   </div>
 </div>


### PR DESCRIPTION
Added Support for Markdown to all alerts:

Directory: `_includes`:
- alert-error.html
- alert-info.html
- alert-no-icon-success.html
- alert-no-icon.html
- alert-slim.html
- alert-success.html
- alert-warning.html

### They now all support both HTML and Markdown
> This is to resolve the issues related to the alerts presenting errors when `"  "` marks are used or when HTML is used inside of an alerts message body, with attributes which require quote marks `"  "`. 

Since the content body of an alert to Ruby is a `String`, it is already surrounded by `"  "` marks, any `"  "` inside of this String will result in an error when Jekyll tries to build. When in doubt you can use the `<b></b> or <strong></strong>`, `<u></u>`, or `<i></i>` HTML tags. 

Anchor Tags: 
When using `<a></a>` tags inside alert boxes, you have to escape the attributes like so: (notice the ` \" `)
``` html
<a href=\"someurl\" target=\"_blank\"></a>
```
> Reason: most programming languages will error out when it sees a set of quote marks inside of another set of quote marks. 

### Site Check:
I have checked alerts on all pages for (the site) this branch after this fix, and they all seem fine except 1, which was not related to `"  "` marks. 

Let me know if you have any questions or see any alerts that need my attention. 

@SuGhadiali 
@TheInfinityBeyonder 
@maxwellfunk