### PR TITLE
Minor Empty Headers and Subnav Items Update

### DIFF
--- a/_includes/alert-error.html
+++ b/_includes/alert-error.html
@@ -1,6 +1,6 @@
 <div class="usa-alert usa-alert--error" role="alert">
   <div class="usa-alert__body">
-    if include.heading %}<h3 class="usa-alert__heading">{{include.heading}}</h3>{% else %}<br/>{% endif %}
+    if include.heading %}<h3 class="usa-alert__heading">{{include.heading}}</h3>{% else %}<br />{% endif %}
     <p class="usa-alert__text">{{include.content | markdownify}}</p>
   </div>
 </div>

--- a/_includes/alert-error.html
+++ b/_includes/alert-error.html
@@ -1,6 +1,6 @@
 <div class="usa-alert usa-alert--error" role="alert">
   <div class="usa-alert__body">
-    if include.heading %}<h3 class="usa-alert__heading">{{include.heading}}</h3>{% else %}<br />{% endif %}
+    if include.heading != "" %}<h3 class="usa-alert__heading">{{include.heading}}</h3>{% else %}<br />{% endif %}
     <p class="usa-alert__text">{{include.content | markdownify}}</p>
   </div>
 </div>

--- a/_includes/alert-error.html
+++ b/_includes/alert-error.html
@@ -1,6 +1,6 @@
 <div class="usa-alert usa-alert--error" role="alert">
   <div class="usa-alert__body">
-    if include.heading != "" %}<h3 class="usa-alert__heading">{{include.heading}}</h3>{% else %}<br />{% endif %}
+    {% if include.heading %}<h3 class="usa-alert__heading">{{include.heading}}</h3>{% else %}<br />{% endif %}
     <p class="usa-alert__text">{{include.content | markdownify}}</p>
   </div>
 </div>

--- a/_includes/alert-error.html
+++ b/_includes/alert-error.html
@@ -1,6 +1,6 @@
 <div class="usa-alert usa-alert--error" role="alert">
   <div class="usa-alert__body">
-    <h3 class="usa-alert__heading">{{include.heading}}</h3>
+    if include.heading %}<h3 class="usa-alert__heading">{{include.heading}}</h3>{% else %}<br/>{% endif %}
     <p class="usa-alert__text">{{include.content | markdownify}}</p>
   </div>
 </div>

--- a/_includes/alert-info.html
+++ b/_includes/alert-info.html
@@ -1,6 +1,6 @@
 <div class="usa-alert usa-alert--info">
   <div class="usa-alert__body">
-    if include.heading %}<h3 class="usa-alert__heading">{{include.heading}}</h3>{% else %}<br/>{% endif %}
+    <h3 class="usa-alert__heading">{{include.heading}}</h3>
     <p class="usa-alert__text">{{include.content | markdownify}}</p>
   </div>
 </div>

--- a/_includes/alert-info.html
+++ b/_includes/alert-info.html
@@ -1,6 +1,6 @@
 <div class="usa-alert usa-alert--info">
   <div class="usa-alert__body">
-    <h3 class="usa-alert__heading">{{include.heading}}</h3>
+    {% if include.heading %}<h3 class="usa-alert__heading">{{include.heading}}</h3>{% else %}<br />{% endif %}
     <p class="usa-alert__text">{{include.content | markdownify}}</p>
   </div>
 </div>

--- a/_includes/alert-info.html
+++ b/_includes/alert-info.html
@@ -1,6 +1,6 @@
 <div class="usa-alert usa-alert--info">
   <div class="usa-alert__body">
-    <h3 class="usa-alert__heading">{{include.heading}}</h3>
+    if include.heading %}<h3 class="usa-alert__heading">{{include.heading}}</h3>{% else %}<br/>{% endif %}
     <p class="usa-alert__text">{{include.content | markdownify}}</p>
   </div>
 </div>

--- a/_includes/alert-success.html
+++ b/_includes/alert-success.html
@@ -1,6 +1,6 @@
 <div class="usa-alert usa-alert--success">
   <div class="usa-alert__body">
-    if include.heading %}<h3 class="usa-alert__heading">{{include.heading}}</h3>{% else %}<br/>{% endif %}
+    <h3 class="usa-alert__heading">{{include.heading}}</h3>
     <p class="usa-alert__text">{{include.content | markdownify}}</p>
   </div>
 </div>

--- a/_includes/alert-success.html
+++ b/_includes/alert-success.html
@@ -1,6 +1,6 @@
 <div class="usa-alert usa-alert--success">
   <div class="usa-alert__body">
-    <h3 class="usa-alert__heading">{{include.heading}}</h3>
+    {% if include.heading %}<h3 class="usa-alert__heading">{{include.heading}}</h3>{% else %}<br />{% endif %}
     <p class="usa-alert__text">{{include.content | markdownify}}</p>
   </div>
 </div>

--- a/_includes/alert-success.html
+++ b/_includes/alert-success.html
@@ -1,6 +1,6 @@
 <div class="usa-alert usa-alert--success">
   <div class="usa-alert__body">
-    <h3 class="usa-alert__heading">{{include.heading}}</h3>
+    if include.heading %}<h3 class="usa-alert__heading">{{include.heading}}</h3>{% else %}<br/>{% endif %}
     <p class="usa-alert__text">{{include.content | markdownify}}</p>
   </div>
 </div>

--- a/_includes/alert-warning.html
+++ b/_includes/alert-warning.html
@@ -1,6 +1,6 @@
 <div class="usa-alert usa-alert--warning">
   <div class="usa-alert__body">
-    <h3 class="usa-alert__heading">{{include.heading}}</h3>
+    {% if include.heading %}<h3 class="usa-alert__heading">{{include.heading}}</h3>{% else %}<br />{% endif %}
     <p class="usa-alert__text">{{include.content | markdownify}}</p>
   </div>
 </div>

--- a/_includes/alert-warning.html
+++ b/_includes/alert-warning.html
@@ -1,6 +1,6 @@
 <div class="usa-alert usa-alert--warning">
   <div class="usa-alert__body">
-    {% if include.heading %}<h3 class="usa-alert__heading">{{include.heading}}</h3>{% endif %}
+    {% if include.heading %}<h3 class="usa-alert__heading">{{include.heading}}</h3>{% else %}<br/>{% endif %}
     <p class="usa-alert__text">{{include.content | markdownify}}</p>
   </div>
 </div>

--- a/_includes/alert-warning.html
+++ b/_includes/alert-warning.html
@@ -1,6 +1,6 @@
 <div class="usa-alert usa-alert--warning">
   <div class="usa-alert__body">
-    {% if include.heading %}<h3 class="usa-alert__heading">{{include.heading}}</h3>{% else %}<br/>{% endif %}
+    <h3 class="usa-alert__heading">{{include.heading}}</h3>
     <p class="usa-alert__text">{{include.content | markdownify}}</p>
   </div>
 </div>

--- a/_includes/alert-warning.html
+++ b/_includes/alert-warning.html
@@ -1,6 +1,6 @@
 <div class="usa-alert usa-alert--warning">
   <div class="usa-alert__body">
-    <h3 class="usa-alert__heading">{{include.heading}}</h3>
+    {% if include.heading %}<h3 class="usa-alert__heading">{{include.heading}}</h3>{% endif %}
     <p class="usa-alert__text">{{include.content | markdownify}}</p>
   </div>
 </div>

--- a/_university/pacs101.md
+++ b/_university/pacs101.md
@@ -717,7 +717,7 @@ E.O. 13636 and PPD-21 - ["Fact Sheet: Improving Critical Infrastructure Cybersec
 
 ## Regulations
 
-[_Federal Acquisition Regulation (FAR)_](https://www.acquisition.gov/browsefar){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"}
+[_Federal Acquisition Regulation (FAR)_](https://www.acquisition.gov/browse/index/far){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"}
 
 ## Standards
 

--- a/assets/css/index.scss
+++ b/assets/css/index.scss
@@ -20,6 +20,11 @@
   max-width: 100%;
 }
 
+// fix height fix for AAA 44px min-height requirement
+// affects sitewide since sidenav is global. 
+.usa-sidenav__item a {
+  min-height: 44px;
+}
 
 // CSS targets, not used for styling, keep empty, used in js to target classes.
 .gsa-target-accordion-header {} // for accordion header targeting

--- a/assets/css/index.scss
+++ b/assets/css/index.scss
@@ -57,6 +57,12 @@
   line-height: 1.5;
 }
 
+// AAA fix for 44 px height for sidenav items.
+.usa-sidenav__item{
+  border-top:1px solid #dfe1e2;
+  height: 44px;
+}
+
 // Important: Colors for H1 and H2 in usa-layout-docs element
 // Updated to base in uswds css file (#005ea2)
 // primary gsa colors are here: https://18f.gsa.gov/assets/blog/web-design-standards/library/14-primary-colors.png

--- a/assets/css/index.scss
+++ b/assets/css/index.scss
@@ -20,12 +20,6 @@
   max-width: 100%;
 }
 
-// AAA issue: sidenav item fix for Interactive elements, 
-// like buttons or links, should be at least 44 by 44 pixels,
-// so they can easily be clicked or tapped by all users.
-.usa-sidenav__item {
-  height: 44px;
-}
 
 // CSS targets, not used for styling, keep empty, used in js to target classes.
 .gsa-target-accordion-header {} // for accordion header targeting

--- a/assets/css/index.scss
+++ b/assets/css/index.scss
@@ -57,12 +57,6 @@
   line-height: 1.5;
 }
 
-// AAA fix for 44 px height for sidenav items.
-.usa-sidenav__item{
-  border-top:1px solid #dfe1e2;
-  height: 44px;
-}
-
 // Important: Colors for H1 and H2 in usa-layout-docs element
 // Updated to base in uswds css file (#005ea2)
 // primary gsa colors are here: https://18f.gsa.gov/assets/blog/web-design-standards/library/14-primary-colors.png

--- a/assets/css/index.scss
+++ b/assets/css/index.scss
@@ -20,6 +20,12 @@
   max-width: 100%;
 }
 
+// AAA issue: sidenav item fix for Interactive elements, 
+// like buttons or links, should be at least 44 by 44 pixels,
+// so they can easily be clicked or tapped by all users.
+.usa-sidenav__item {
+  height: 44px;
+}
 
 // CSS targets, not used for styling, keep empty, used in js to target classes.
 .gsa-target-accordion-header {} // for accordion header targeting

--- a/assets/css/index.scss
+++ b/assets/css/index.scss
@@ -20,8 +20,8 @@
   max-width: 100%;
 }
 
-// fix height fix for AAA 44px min-height requirement
-// affects sitewide since sidenav is global. 
+// Height fix for AAA 44px min-height requirement
+// affects sitewide AAA score since sidenav is global. 
 .usa-sidenav__item a {
   min-height: 44px;
 }


### PR DESCRIPTION
Minor fixes to address AAA issues flagged in `SI`.

## Empty Headers Update

- Fixed empty headers sitewide related to alerts (call-out-boxes): info, success, warning, errors.
- I placed logic in the alert templates as a safeguard against empty headings, if a heading is left empty, it will not print the HTML header code on the page but will add a `<br />` in its' place to preserve spacing to promote readability. 
> Alerts are templates included in place on a page, these alerts take parameters; for some (52), the heading were left blank. These empty headings affect the AAA score, reducing these should increase the AAA score by some measure.

## Subnav Items Height Update

- Added CSS `min-height` to the stylesheet (`assets/css/index.scss`) to restrict `subnav items` that appear in **sidenavs** from displaying smaller in height than `44px`. 
-  This added a small amount of spacing to the bottom of `subnav items` helping with readability and gives users on touch screens more area to press `subnav items` .
- This should increase the AAA score by some measure. 
> `SI` was flagging any `subnav items`  whos height was smaller than `44px` in height, `subnav items` with more characters in their `title-text` normally display larger than 44px in height and were not being flagged.  

## Broken Links

> Only two broken links are addressed in this update, but may have already been addressed in previous updates. `SI` may recheck and reflag these if scanned before this update goes to Prod. 

@SuGhadiali 
@TheInfinityBeyonder 

📅 01/29/2025 👍 
 