### PR TITLE
0319-iarpa-hiatus-update

### DIFF
--- a/_experiments/introduction.md
+++ b/_experiments/introduction.md
@@ -23,9 +23,9 @@ Please reach out to [icam@gsa.gov](mailto:icam@gsa.gov) with ideas, questions, a
 The HIATUS (Human Interpretable Attribution of Text using Underlying Structure) program aims to address various Intelligence Community (IC) and Law Enforcement (LE) needs such as combating sophisticated malicious information campaigns online, addressing counterintelligence risks, and fighting human trafficking and online fraud. It does so by developing novel Artificial Intelligence (AI) systems for attributing document authorship (Who is the author of this text?) in an explainable way (What is 
 the evidence of authorship?), detecting AI-generated text (Was this document written by human or machine?) and protecting author privacy (How do I ensure that my writing is not attributable?). 
 
-To learn more about IARPA HIATUS and how it works, click the button below.
+To learn more about the **IARPA HIATUS** program and how it works, click the button below.
 
-<a href="https://www.iarpa.gov/research-programs/hiatus" style="color:white text-decoration:none" target="_blank">
+<a href="https://www.iarpa.gov/research-programs/hiatus" style="color:white; text-decoration:none;" target="_blank">
   <button class="usa-button usa-link usa-link--external">Explore Further</button>
 </a>
 

--- a/_experiments/introduction.md
+++ b/_experiments/introduction.md
@@ -25,8 +25,8 @@ the evidence of authorship?), detecting AI-generated text (Was this document wri
 
 To learn more about IARPA HIATUS and how it works, click the button below.
 
-<a href="" style="color:white;text-decoration:none">
-  <button class="usa-button">Explore Further</button>
+<a href="https://www.iarpa.gov/research-programs/hiatus" style="color:white text-decoration:none" target="_blank">
+  <button class="usa-button usa-link usa-link--external">Explore Further</button>
 </a>
 
 

--- a/_experiments/introduction.md
+++ b/_experiments/introduction.md
@@ -25,7 +25,7 @@ the evidence of authorship?), detecting AI-generated text (Was this document wri
 
 To learn more about the **IARPA HIATUS** program and how it works, click the button below.
 
-<a href="https://www.iarpa.gov/research-programs/hiatus" style="text-decoration:none;" target="_blank">
+<a href="https://www.iarpa.gov/research-programs/hiatus" style="text-decoration:none;" target="_blank" title="IARPA HIATUS Program">
   <button class="usa-button usa-link usa-link--external" style="color:#ffffff;">Explore Further</button>
 </a>
 

--- a/_experiments/introduction.md
+++ b/_experiments/introduction.md
@@ -20,7 +20,7 @@ Please reach out to [icam@gsa.gov](mailto:icam@gsa.gov) with ideas, questions, a
 
 ## IARPA HIATUS
 
-The HIATUS (_Human Interpretable Attribution of Text using Underlying Structure_) program aims to address various Intelligence Community (IC) and Law Enforcement (LE) needs such as combating sophisticated malicious information campaigns online, addressing counterintelligence risks, and fighting human trafficking and online fraud. It does so by developing novel Artificial Intelligence (AI) systems for attributing document authorship (Who is the author of this text?) in an explainable way (What is 
+The HIATUS - _Human Interpretable Attribution of Text using Underlying Structure_ program aims to address various Intelligence Community (IC) and Law Enforcement (LE) needs such as combating sophisticated malicious information campaigns online, addressing counterintelligence risks, and fighting human trafficking and online fraud. It does so by developing novel Artificial Intelligence (AI) systems for attributing document authorship (Who is the author of this text?) in an explainable way (What is 
 the evidence of authorship?), detecting AI-generated text (Was this document written by human or machine?) and protecting author privacy (How do I ensure that my writing is not attributable?). 
 
 To learn more about the **IARPA HIATUS** program and how it works, click the button below.

--- a/_experiments/introduction.md
+++ b/_experiments/introduction.md
@@ -26,7 +26,8 @@ the evidence of authorship?), detecting AI-generated text (Was this document wri
 To learn more about the **IARPA HIATUS** program and how it works, click the button below.
 
 <a href="https://www.iarpa.gov/research-programs/hiatus" 
-   style="text-decoration:none;" target="_blank" 
+   style="text-decoration:none;" 
+   target="_blank" 
    title="IARPA HIATUS Program">
   <button class="usa-button usa-link usa-link--external" style="color:#ffffff;">Explore Further</button>
 </a>

--- a/_experiments/introduction.md
+++ b/_experiments/introduction.md
@@ -25,8 +25,8 @@ the evidence of authorship?), detecting AI-generated text (Was this document wri
 
 To learn more about the **IARPA HIATUS** program and how it works, click the button below.
 
-<a href="https://www.iarpa.gov/research-programs/hiatus" style="color:white; text-decoration:none;" target="_blank">
-  <button class="usa-button usa-link usa-link--external">Explore Further</button>
+<a href="https://www.iarpa.gov/research-programs/hiatus" style="text-decoration:none;" target="_blank">
+  <button class="usa-button usa-link usa-link--external" style="color:#ffffff;">Explore Further</button>
 </a>
 
 

--- a/_experiments/introduction.md
+++ b/_experiments/introduction.md
@@ -25,7 +25,9 @@ the evidence of authorship?), detecting AI-generated text (Was this document wri
 
 To learn more about IARPA HIATUS and how it works, click the button below.
 
-[Explore Further](https://www.iarpa.gov/research-programs/hiatus){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external usa-button"}
+<a href="" style="color:white;text-decoration:none">
+  <button class="usa-button">Explore Further</button>
+</a>
 
 
 

--- a/_experiments/introduction.md
+++ b/_experiments/introduction.md
@@ -25,7 +25,9 @@ the evidence of authorship?), detecting AI-generated text (Was this document wri
 
 To learn more about the **IARPA HIATUS** program and how it works, click the button below.
 
-<a href="https://www.iarpa.gov/research-programs/hiatus" style="text-decoration:none;" target="_blank" title="IARPA HIATUS Program">
+<a href="https://www.iarpa.gov/research-programs/hiatus" 
+   style="text-decoration:none;" target="_blank" 
+   title="IARPA HIATUS Program">
   <button class="usa-button usa-link usa-link--external" style="color:#ffffff;">Explore Further</button>
 </a>
 

--- a/_experiments/introduction.md
+++ b/_experiments/introduction.md
@@ -20,7 +20,7 @@ Please reach out to [icam@gsa.gov](mailto:icam@gsa.gov) with ideas, questions, a
 
 ## IARPA HIATUS
 
-The HIATUS (Human Interpretable Attribution of Text using Underlying Structure) program aims to address various Intelligence Community (IC) and Law Enforcement (LE) needs such as combating sophisticated malicious information campaigns online, addressing counterintelligence risks, and fighting human trafficking and online fraud. It does so by developing novel Artificial Intelligence (AI) systems for attributing document authorship (Who is the author of this text?) in an explainable way (What is 
+The HIATUS (_Human Interpretable Attribution of Text using Underlying Structure_) program aims to address various Intelligence Community (IC) and Law Enforcement (LE) needs such as combating sophisticated malicious information campaigns online, addressing counterintelligence risks, and fighting human trafficking and online fraud. It does so by developing novel Artificial Intelligence (AI) systems for attributing document authorship (Who is the author of this text?) in an explainable way (What is 
 the evidence of authorship?), detecting AI-generated text (Was this document written by human or machine?) and protecting author privacy (How do I ensure that my writing is not attributable?). 
 
 To learn more about the **IARPA HIATUS** program and how it works, click the button below.

--- a/_experiments/introduction.md
+++ b/_experiments/introduction.md
@@ -20,22 +20,14 @@ Please reach out to [icam@gsa.gov](mailto:icam@gsa.gov) with ideas, questions, a
 
 ## IARPA HIATUS
 
-The HIATUS program aims to address various Intelligence Community (IC) and Law Enforcement (LE) needs such as combating sophisticated malicious information campaigns online, addressing counterintelligence risks, and fighting human trafficking and online fraud. It does so by developing novel Artificial Intelligence (AI) systems for attributing document authorship (Who is the author of this text?) in an explainable way (What is 
-the evidence of authorship?), detecting AI-generated text (Was this document written by human or machine?) and protecting author privacy (How do I ensure that my writing is not attributable?).
+The HIATUS (Human Interpretable Attribution of Text using Underlying Structure) program aims to address various Intelligence Community (IC) and Law Enforcement (LE) needs such as combating sophisticated malicious information campaigns online, addressing counterintelligence risks, and fighting human trafficking and online fraud. It does so by developing novel Artificial Intelligence (AI) systems for attributing document authorship (Who is the author of this text?) in an explainable way (What is 
+the evidence of authorship?), detecting AI-generated text (Was this document written by human or machine?) and protecting author privacy (How do I ensure that my writing is not attributable?). 
 
-<script>
-  // Selecting the iframe element
-  var frame = document.getElementById("hiatus");
-  
-  // Adjusting the iframe height onload event
-  frame.onload = function() {
-      // set the height of the iframe as 
-      // the height of the iframe content
-      frame.style.height = frame.contentWindow.document.body.height + 'px';
+To learn more about IARPA HIATUS and how it works, click the button below.
 
-      // set the width of the iframe as the 
-      // width of the iframe content
-      frame.style.width  = frame.contentWindow.document.body.scrollWidth + 'px';
-  }
-</script>
-<iframe id="hiatus" title="IARPA HIATUS Slicksheet PDF" src="{{site.baseurl}}/docs/expdocs/HIATUS_SlickSheet_20250131.pdf#toolbar=1&zoom=100&view=Fit" width="100%" height="792px"></iframe>
+[Explore Further](https://www.iarpa.gov/research-programs/hiatus){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external usa-button"}
+
+
+
+
+


### PR DESCRIPTION
## Updates

- added the expanded acronym after the first use of HIATUS.
- added a CTA (call-to-action) link to the IARPA HIATUS page, after summary content. 
- IARPA HIATUS Page Link: https://www.iarpa.gov/research-programs/hiatus 
> Note: the [IARPA HIATUS page](https://www.iarpa.gov/research-programs/hiatus) is both desktop and mobile friendly.

@SuGhadiali 

📅 03/19/2025 ☕ 