### PR TITLE
0415-menu-and-playbook-update

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -117,8 +117,6 @@ primary_navigation:
     children: 
     - name: Introduction
       url: /experiments/
-    - name: Identity Fraud Detection Playbook
-      url: /experiments/idfraud/
 
 secondary_navigation:
   - name: Contact Us

--- a/_config.yml
+++ b/_config.yml
@@ -43,7 +43,7 @@ ga:
 primary_navigation:
   - name: Home
     url: /
-  - name: Why FICAM
+  - name: FICAM
     children:
       - name: FICAM Architecture
         url: /arch/
@@ -83,7 +83,7 @@ primary_navigation:
         url: /implement/yubikey-guide/
       - name: Unifyia Implementation Guide for Passkeys (FIDO2)
         url: /implement/unifyia-guide/
-  - name: Coordination Functions
+  - name: Functions
     children: 
       - name: FICAM Program
         url: /ficam/

--- a/_data/gsacarousel.yml
+++ b/_data/gsacarousel.yml
@@ -81,11 +81,3 @@
   actionLocation: playbooks/cloud/
   actionTarget: _self
 
-- orderNumber: 7
-  initialState:
-  delay: 10000
-  heroHeading: Identity lifecycle management
-  heroText: encompasses the activities of creating, identity proofing, vetting, provisioning, aggregating, maintaining, and deactivating digital identities on an agency’s enterprise identity, credential, and access management (ICAM) system.
-  actionButtonText: Learn more about
-  actionLocation: playbooks/ilm/
-  actionTarget: _self

--- a/_data/gsacarousel.yml
+++ b/_data/gsacarousel.yml
@@ -20,11 +20,11 @@
 
 - orderNumber: 0
   initialState: active
-  delay: 20000
-  heroHeading: "ICAM FIBF" 
-  heroText: "The ICAM FIBF Working Group has released Component 4 and 5 for Comment."
+  delay: 30000
+  heroHeading: "Identity Fraud Detection Playbook" 
+  heroText: "This playbook serves as a resource and provides a foundational understanding of identity fraud techniques, detection methods, and mitigation strategies."
   actionButtonText: Learn more about the 
-  actionLocation: icam-fibf/
+  actionLocation: playbooks/idfraud/
   actionTarget: _self
 
 - orderNumber: 1

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -110,6 +110,8 @@ playbooks:
     href: /playbooks/altauthn/
   - text: ICAM Governance Framework Version 1.0
     href: /docs/playbook-identity-governance-framework.pdf
+  - text: Identity Fraud Detection Playbook
+    href: /playbooks/idfraud/
   - text: Identity Lifecycle Management Playbook
     href: /playbooks/ilm/ 
   - text: Privileged Identity Playbook

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -86,8 +86,6 @@ university:
 experiments:
   - text: Experiments
     href: /experiments/     
-  - text: Identity Fraud Detection
-    href: /experiments/idfraud/
 
 playbooks:
   - text: Introduction

--- a/_data/playbooks.yml
+++ b/_data/playbooks.yml
@@ -66,6 +66,14 @@
   header: "/assets/playbooks/headers/playbook_07.webp"
   target: _self
 
+- title: Identity Fraud Detection Playbook
+  type: Webpage
+  pubdate: 2025-02
+  description: This playbook serves as a resource and provides a foundational understanding of identity fraud techniques, detection methods, and mitigation strategies.
+  url: "/playbooks/idfraud/"
+  header: "/assets/playbooks/headers/playbook_06.webp"
+  target: _self
+
 - title: Identity Lifecycle Management Playbook
   type: Webpage
   pubdate: 2024-18

--- a/_playbooks/playbook-idfraud.md
+++ b/_playbooks/playbook-idfraud.md
@@ -1,9 +1,10 @@
 ---
 layout: page
-collection: experiments
+collection: playbooks
 title:  Identity Fraud Detection Playbook
-permalink: /experiments/idfraud/
-sidenav: experiments
+permalink: /playbooks/idfraud/
+description: This playbook serves as a resource and provides a foundational understanding of identity fraud techniques, detection methods, and mitigation strategies.
+sidenav: playbooks
 sticky_sidenav: true
 
 pubdate: February 2025

--- a/_university/piv101.md
+++ b/_university/piv101.md
@@ -87,7 +87,7 @@ To review the standards, there is a [National Institute of Standards and Technol
 
 ## How Can I Test a PIV Card?
 
-The [Card Conformance Tool (CCT)](https://github.com/GSA/piv-conformance/wiki/User-Guide){:target="_blank"}{:rel="noopener noreferrer"} can remotely test PIV and Personal Identity Verification–Interoperable (PIV-I) on several common operating systems. The purpose of the CCT is to validate that commercially available PIV and PIV-I comply with relevant standards.
+The [Card Conformance Tool (CCT)](https://github.com/GSA/piv-conformance/releases){:target="_blank"}{:rel="noopener noreferrer"} can remotely test PIV and Personal Identity Verification–Interoperable (PIV-I) on several common operating systems. The purpose of the CCT is to validate that commercially available PIV and PIV-I comply with relevant standards.
 
 ## PIV Overview
 


### PR DESCRIPTION
## Updates

- moved `Identity Fraud Playbook` to `Playbooks` (Final).
- updated menu text to shorten the menu's total menu length.
- removed `idfraud playbook` from exp `sidenav`.
- removed `idfraud` from menu.
- added `idfraud` Playbook to the rotator.
- removed `ILM` from rotator.
- updated moved from weekly updates: link to `CCT Tool`, linking to release page.

@SuGhadiali 

📅 04/15/2025 ☕ 