### PR TITLE
0506: update @uswds/uswds from 3.11.0 to 3.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "pa11y-ci:sitemap": "pa11y-ci --sitemap http://localhost:4000/sitemap.xml --sitemap-exclude \"/*.pdf\""
   },
   "dependencies": {
-    "@uswds/uswds": "3.11.0"
+    "@uswds/uswds": "3.12.0"
   },
   "devDependencies": {
     "pa11y-ci": "^2.4.0",


### PR DESCRIPTION
## Updates

[PREVIEW](https://federalist-cf03235f-a054-4178-aafb-4e1e61e0d42c.sites.pages.cloud.gov/preview/gsa/idmanagement.gov/0506-idm-uswds-version-update/)

- [Minor version update.](https://github.com/uswds/uswds/releases/tag/v3.12.0)
- Updated USWDS from `3.11.0` to `3.12.0`
- I did not see any visible breaking changes on the website or breaks in code in the preview. 
>  After an update of the  USWDS version, I normally watch the site for a week. 👀 👍 

@SuGhadiali 

📅 05-06-2025