### PR TITLE
0507-idm-ficam-policy-matrix-update

### DIFF
--- a/_data/laws-policies-standards.yml
+++ b/_data/laws-policies-standards.yml
@@ -783,7 +783,7 @@
 - &SP180013
   type: Guidance
   shortName: "NIST SP 1800-13"
-  longName: "NIST SPECIAL PUBLICATION 1800-13A Mobile Application Single Sign-On: Improving Authentication for Public Safety First Responders"
+  longName: "NIST SPECIAL PUBLICATION 1800-13: A Mobile Application Single Sign-On: Improving Authentication for Public Safety First Responders"
   description: >-
     This NIST Cybersecurity Practice Guide describes how organizations can implement Mobile SSO
     technologies to enhance public safety mission capabilities by using standards-based

--- a/_data/laws-policies-standards.yml
+++ b/_data/laws-policies-standards.yml
@@ -1561,7 +1561,7 @@
   type: Guidance
   shortName: "NIST SP 800-78"
   longName: "NIST Special Publication 800-78: Cryptographic Algorithms and Key Sizes for Personal Identity Verification"
-  description: "This document contains the technical specifications needed for the mandatory and optional cryptographic keys specified in FIPS 201-2 as well as the supporting infrastructure specified in FIPS 201-2 and the related NIST Special Publication 800-73-4, Interfaces for Personal Identity Verification [SP800-73], and NIST SP 800-76-2, Biometric Specifications for Personal Identity Verification [SP800-76], that rely on cryptographic functions."
+  description: "This document contains the technical specifications needed for the mandatory and optional cryptographic keys specified in FIPS 201-3, as well as the supporting infrastructure specified in FIPS 201-3 and the related NIST Special Publication (SP) 800-73, Interfaces for Personal Identity Verification, and SP 800-76, Biometric Specifications for Personal Identity Verification, which rely on cryptographic functions."
   externalURL: "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-78-5.pdf"
   published: 2024-07-15
   authored-by:

--- a/_data/laws-policies-standards.yml
+++ b/_data/laws-policies-standards.yml
@@ -1686,7 +1686,7 @@
     This document provides guidance for federal Executive Branch departments and agencies regarding 
     access control requirements and options for individuals entering federally occupied space
   published: 2020-12-17
-  externalURL: "https://www.cisa.gov/sites/default/files/publications/Facility%20Access%20Control%20-%20An%20Interagency%20Security%20Committee%20Best%20Practice.pdf"
+  externalURL: "https://www.cisa.gov/sites/default/files/2025-02/Facility%20Access%20Control%20-%20An%20Interagency%20Security%20Committee%20Best%20Practice-02-20.pdf"
   authored-by:
     - *ISC
   ficam-services:

--- a/_data/laws-policies-standards.yml
+++ b/_data/laws-policies-standards.yml
@@ -759,7 +759,7 @@
     Describes trust frameworks for identity federations, which provide a secure method for leveraging shared 
     identity credentials across communities of similarly-focused online service providers.
   published: 2018-01-12
-  externalURL: "https://csrc.nist.gov/publications/detail/nistir/8149/final"
+  externalURL: "https://nvlpubs.nist.gov/nistpubs/ir/2018/NIST.IR.8149.pdf"
   authored-by:
     - *NIST
   ficam-services:
@@ -789,7 +789,7 @@
     technologies to enhance public safety mission capabilities by using standards-based
     commercially available or open-source products.
   published: 2021-08-25
-  externalURL: "https://csrc.nist.gov/pubs/sp/1800/13/final"
+  externalURL: "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.1800-13.pdf"
   authored-by:
     - *NIST
   ficam-services:
@@ -1035,8 +1035,8 @@
     credential service provider (CSP) reliably identifying themselves, thereby allowing the CSP to assert 
     that identification at an Identity Assurance Level (IAL). This document defines technical requirements 
     for each of the three IALs.
-  externalURL: "https://csrc.nist.gov/publications/detail/sp/800-63a/4/draft"
-  published: 2022-12-16
+  externalURL: "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-63A-4.2pd.pdf"
+  published: 2024-08-21
   authored-by:
     - *NIST
   authorized-by:
@@ -1057,8 +1057,8 @@
     result of the authentication process may be used locally by the system performing the authentication or 
     may be asserted elsewhere in a federated identity system. This document defines technical requirements 
     for each of the three Authentication Assurance Levels (AALs).
-  externalURL: "https://csrc.nist.gov/publications/detail/sp/800-63b/4/draft"
-  published: 2022-12-16
+  externalURL: "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-63B-4.2pd.pdf "
+  published: 2024-08-21
   authored-by:
     - *NIST
   authorized-by:
@@ -1080,8 +1080,8 @@
     focuses on the use of federated identity and the use of assertions to implement identity federations. 
     Federation allows a given CSP to provide authentication and (optionally) subscriber attributes to a number 
     of separately-administered relying parties. Similarly, relying parties may use more than one CSP.
-  externalURL: "https://csrc.nist.gov/publications/detail/sp/800-63c/4/draft"
-  published: 2022-12-16
+  externalURL: "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-63C-4.2pd.pdf"
+  published: 2024-08-21
   authored-by:
     - *NIST
   authorized-by:
@@ -1321,12 +1321,12 @@
 - &SP800171
   type: Guidance
   shortName: NIST SP 800-171
-  longName: "NIST Special Publication 800-171 Revision 2: Protecting Controlled Unclassified Information in Nonfederal Systems and Organizations"
+  longName: "NIST Special Publication 800-171 Revision 3: Protecting Controlled Unclassified Information in Nonfederal Systems and Organizations"
   description: >-
     This publication provides guidance for operators of non-federal (e.g. commercial) systems hosting Controlled 
     Unclassified Information (CUI). It includes several FICAM relevant requirements.
-  published: 2021-01-28
-  externalURL: "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171r2.pdf"
+  published: 2021-05-01
+  externalURL: "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171Ar3.pdf"
   authored-by:
     - *NIST
   authorized-by:
@@ -1478,8 +1478,8 @@
   shortName: "NIST SP 800-73"
   longName: "NIST Special Publication 800-73-4: Interfaces for Personal Identity Verification"
   description: "This document, SP 800-73, contains the technical specifications to interface with the smart card to retrieve and use the PIV identity credentials."
-  externalURL: "https://csrc.nist.gov/publications/detail/sp/800-73/4/final"
-  published: 2016-02-12
+  externalURL: "https://csrc.nist.gov/pubs/sp/800/73/pt1/5/final"
+  published: 2024-07-15
   authored-by:
     - *NIST
   subspec-of:
@@ -1562,8 +1562,8 @@
   shortName: "NIST SP 800-78"
   longName: "NIST Special Publication 800-78: Cryptographic Algorithms and Key Sizes for Personal Identity Verification"
   description: "This document contains the technical specifications needed for the mandatory and optional cryptographic keys specified in FIPS 201-2 as well as the supporting infrastructure specified in FIPS 201-2 and the related NIST Special Publication 800-73-4, Interfaces for Personal Identity Verification [SP800-73], and NIST SP 800-76-2, Biometric Specifications for Personal Identity Verification [SP800-76], that rely on cryptographic functions."
-  externalURL: "https://csrc.nist.gov/publications/detail/sp/800-78/4/final"
-  published: 2015-05-29
+  externalURL: "https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-78-5.pdf"
+  published: 2024-07-15
   authored-by:
     - *NIST
   subspec-of:

--- a/_data/laws-policies-standards.yml
+++ b/_data/laws-policies-standards.yml
@@ -1476,7 +1476,7 @@
 - &SP80073
   type: Guidance
   shortName: "NIST SP 800-73"
-  longName: "NIST Special Publication 800-73-4: Interfaces for Personal Identity Verification"
+  longName: "NIST Special Publication 800-73-5: Interfaces for Personal Identity Verification"
   description: "This document, SP 800-73, contains the technical specifications to interface with the smart card to retrieve and use the PIV identity credentials."
   externalURL: "https://csrc.nist.gov/pubs/sp/800/73/pt1/5/final"
   published: 2024-07-15

--- a/_university/ficampolicymap.md
+++ b/_university/ficampolicymap.md
@@ -785,7 +785,7 @@ sticky_sidenav: true
       </a>
     </g>
     <g id="SP_800-63C1" data-name="SP 800-63C1">
-      <a href="https://csrc.nist.gov/pubs/sp/800/63/c/4/ipd" title="SP 800-63C1" target="_blank" rel="noopener noreferrer">
+      <a href="https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-63C-4.2pd.pdf" title="SP 800-63C1" target="_blank" rel="noopener noreferrer">
       <rect class="tsbutton" id="gbrect-35" data-name="gbrect" x="346.28" y="765.3" width="74.22" height="17.23" />
       <text id="SP_800-63C1-2" data-name="SP 800-63C-2" transform="translate(355.85 777.03) scale(1.27 1)" style="font-family: Arial-BoldMT, Arial; font-size: 8px; font-weight: 700;"><tspan x="0" y="0">S</tspan><tspan x="5.34" y="0" style="letter-spacing: -.02em;">P</tspan><tspan x="10.53" y="0" xml:space="preserve"> 800-63C</tspan></text>
       </a>

--- a/_university/ficampolicymap.md
+++ b/_university/ficampolicymap.md
@@ -700,7 +700,7 @@ sticky_sidenav: true
       </a>
     </g>
     <g id="SP_1800-13" data-name="SP 1800-13">
-      <a href="https://csrc.nist.gov/pubs/sp/1800/13/final" title="SP 1800-13" target="_blank" rel="noopener noreferrer">
+      <a href="https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.1800-13.pdf" title="SP 1800-13" target="_blank" rel="noopener noreferrer">
       <rect id="gbrect-22" class="tsbutton" data-name="gbrect" x="47.41" y="674.3" width="90.19" height="41.5"/>
       <text id="SP_1800-13-2" data-name="SP 1800-13" transform="translate(66.58 698.56)" style="font-family: Arial-BoldMT, Arial; font-size: 9.8px; font-weight: 700;"><tspan x="0" y="0">S</tspan><tspan x="6.53" y="0" style="letter-spacing: -.02em;">P</tspan><tspan x="12.89" y="0" xml:space="preserve"> 1800-13</tspan></text>
       </a>

--- a/_university/ficampolicymap.md
+++ b/_university/ficampolicymap.md
@@ -896,7 +896,7 @@ sticky_sidenav: true
       </a>
     </g>
     <g id="SP_800-171" data-name="SP 800-171">
-      <a href="https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171r2.pdf" title="SP 800-171" target="_blank" rel="noopener noreferrer">
+      <a href="https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171Ar3.pdf" title="SP 800-171" target="_blank" rel="noopener noreferrer">
       <rect class="tsbutton" id="gbrect-51" data-name="gbrect" x="787.23" y="544.3" width="80.27" height="23" />
       <text id="SP_800-171-2" data-name="SP 800-171" transform="translate(799.48 559) scale(1.33 1)" style="font-family: Arial-BoldMT, Arial; font-size: 8px; font-weight: 700;"><tspan x="0" y="0">S</tspan><tspan x="5.34" y="0" style="letter-spacing: -.02em;">P</tspan><tspan x="10.53" y="0" xml:space="preserve"> 800-171</tspan></text>
       </a>

--- a/_university/ficampolicymap.md
+++ b/_university/ficampolicymap.md
@@ -878,7 +878,7 @@ sticky_sidenav: true
       </a>
     </g>
     <g id="SP_800-78" data-name="SP 800-78">
-      <a href="https://csrc.nist.gov/pubs/sp/800/78/4/final" title="SP 800-78" target="_blank" rel="noopener noreferrer">
+      <a href="https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-78-5.pdf" title="SP 800-78" target="_blank" rel="noopener noreferrer">
       <rect class="tsbutton" id="gbrect-48" data-name="gbrect" x="967.23" y="678.3" width="76.34" height="25.1" />
       <text id="SP_800-78-2" data-name="SP 800-78" transform="translate(980.44 694) scale(1.33 1)" style="font-family: Arial-BoldMT, Arial; font-size: 8px; font-weight: 700;"><tspan x="0" y="0">S</tspan><tspan x="5.34" y="0" style="letter-spacing: -.02em;">P</tspan><tspan x="10.53" y="0" xml:space="preserve"> 800-78</tspan></text>
       </a>

--- a/_university/ficampolicymap.md
+++ b/_university/ficampolicymap.md
@@ -927,7 +927,7 @@ sticky_sidenav: true
       </a>
     </g>
     <g id="Facility_Acess" data-name="Facility Acess"><!-- site down at time of update -->
-      <a href="https://www.cisa.gov/sites/default/files/publications/Facility%20Access%20Control%20-%20An%20Interagency%20Security%20Committee%20Best%20Practice.pdf" title="Facility Acess Control" target="_blank" rel="noopener noreferrer">
+      <a href="https://www.cisa.gov/sites/default/files/2025-02/Facility%20Access%20Control%20-%20An%20Interagency%20Security%20Committee%20Best%20Practice-02-20.pdf" title="Facility Acess Control" target="_blank" rel="noopener noreferrer">
       <rect class="tsbutton" id="gbrect-56" data-name="gbrect" x="1306.5" y="864.3" width="111" height="51" />
       <text id="Facility_Acess-2" data-name="Facility Acess" transform="translate(1327.19 887.16) scale(1.33 1)" style="font-family: Arial-BoldMT, Arial; font-size: 8px; font-weight: 700;"><tspan x="0" y="0">Facility</tspan><tspan x="27.57" y="0" style="letter-spacing: -.04em;"> </tspan><tspan x="29.49" y="0">Acess</tspan><tspan x="12.31" y="12">Control</tspan></text>
       </a>

--- a/_university/ficampolicymap.md
+++ b/_university/ficampolicymap.md
@@ -814,7 +814,7 @@ sticky_sidenav: true
       </a>
     </g>
     <g id="NISTIR_8149" data-name="NISTIR 8149">
-      <a href="https://csrc.nist.gov/pubs/ir/8149/final" title="NISTIR 8149" target="_blank" rel="noopener noreferrer">
+      <a href="https://nvlpubs.nist.gov/nistpubs/ir/2018/NIST.IR.8149.pdf" title="NISTIR 8149" target="_blank" rel="noopener noreferrer">
       <rect class="tsbutton" id="gbrect-39" data-name="gbrect" x="487.28" y="795.3" width="90.22" height="31" />
       <text id="NISTIR_8149t" data-name="NISTIR 8149t" transform="translate(499.39 814.38) scale(1.27 1)" style="font-family: Arial-BoldMT, Arial; font-size: 9px; font-weight: 700;"><tspan x="0" y="0">NISTIR 8149</tspan></text>
       </a>

--- a/_university/ficampolicymap.md
+++ b/_university/ficampolicymap.md
@@ -842,7 +842,7 @@ sticky_sidenav: true
       <text id="FIPS_201_related_standards" data-name="FIPS 201 related standards" transform="translate(831.76 658.74) scale(1.27 1)" style="font-family: ArialMT, Arial; font-size: 11px;"><tspan x="0" y="0">FIPS 201 related standards</tspan></text>
     </g>
     <g id="SP_800-73" data-name="SP 800-73">
-      <a href="https://csrc.nist.gov/pubs/sp/800/73/4/upd1/final" title="SP 800-73" target="_blank" rel="noopener noreferrer">
+      <a href="https://csrc.nist.gov/pubs/sp/800/73/pt1/5/final" title="SP 800-73" target="_blank" rel="noopener noreferrer">
       <rect class="tsbutton" id="gbrect-42" data-name="gbrect" x="787.23" y="678.3" width="76.34" height="25.1" />
       <text id="SP_800-73-2" data-name="SP 800-73" transform="translate(800.44 694) scale(1.33 1)" style="font-family: Arial-BoldMT, Arial; font-size: 8px; font-weight: 700;"><tspan x="0" y="0">S</tspan><tspan x="5.34" y="0" style="letter-spacing: -.02em;">P</tspan><tspan x="10.53" y="0" xml:space="preserve"> 800-73</tspan></text>
       </a>

--- a/_university/ficampolicymap.md
+++ b/_university/ficampolicymap.md
@@ -773,7 +773,7 @@ sticky_sidenav: true
       </a>
     </g>
     <g id="SP_800-63A" data-name="SP 800-63A">
-      <a href="https://csrc.nist.gov/pubs/sp/800/63/a/4/ipd" title="SP 800-63A" target="_blank" rel="noopener noreferrer">
+      <a href="https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-63A-4.2pd.pdf" title="SP 800-63A" target="_blank" rel="noopener noreferrer">
       <rect class="tsbutton" id="gbrect-33" data-name="gbrect" x="346.28" y="725.3" width="74.22" height="17.23" />
       <text id="SP_800-63A-2" data-name="SP 800-63A" transform="translate(355.85 737.03) scale(1.27 1)" style="font-family: Arial-BoldMT, Arial; font-size: 8px; font-weight: 700;"><tspan x="0" y="0">S</tspan><tspan x="5.34" y="0" style="letter-spacing: -.02em;">P</tspan><tspan x="10.53" y="0" xml:space="preserve"> 800-63</tspan><tspan x="37.66" y="0" style="letter-spacing: -.04em;">A</tspan></text>
       </a>

--- a/_university/ficampolicymap.md
+++ b/_university/ficampolicymap.md
@@ -779,7 +779,7 @@ sticky_sidenav: true
       </a>
     </g>
     <g id="SP_800-63B" data-name="SP 800-63B">
-      <a href="https://csrc.nist.gov/pubs/sp/800/63/b/4/ipd" title="SP 800-63B" target="_blank" rel="noopener noreferrer">
+      <a href="https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-63B-4.2pd.pdf" title="SP 800-63B" target="_blank" rel="noopener noreferrer">
       <rect class="tsbutton" id="gbrect-34" data-name="gbrect" x="346.28" y="745.3" width="74.22" height="17.23" />
       <text id="SP_800-63B-2" data-name="SP 800-63B" transform="translate(355.85 757.03) scale(1.27 1)" style="font-family: Arial-BoldMT, Arial; font-size: 8px; font-weight: 700;"><tspan x="0" y="0">S</tspan><tspan x="5.34" y="0" style="letter-spacing: -.02em;">P</tspan><tspan x="10.53" y="0" xml:space="preserve"> 800-63B</tspan></text>
       </a>

--- a/_university/ficampolicymatrix.md
+++ b/_university/ficampolicymatrix.md
@@ -428,9 +428,9 @@ Some of the documents referenced in this matrix are managed by other agencies an
 
 |  Name	     |  Status |
 |:-----------|----|
-| [SP 800-63A-4](https://csrc.nist.gov/pubs/sp/800/63/a/4/2pd){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"} | Updated |
-| [SP 800-63B-4](https://csrc.nist.gov/pubs/sp/800/63/b/4/2pd){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"} | Updated |	
-| [SP 800-63C-4](https://csrc.nist.gov/pubs/sp/800/63/c/4/2pd){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"} | Updated |
+| [SP 800-63A-4 (2nd Public Draft)](https://csrc.nist.gov/pubs/sp/800/63/a/4/2pd){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"} | Updated |
+| [SP 800-63B-4 (2nd Public Draft)](https://csrc.nist.gov/pubs/sp/800/63/b/4/2pd){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"} | Updated |	
+| [SP 800-63C-4 (2nd Public Draft)](https://csrc.nist.gov/pubs/sp/800/63/c/4/2pd){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"} | Updated |
 | [SP 800-73-5 Pt 1](https://csrc.nist.gov/pubs/sp/800/73/pt1/5/final){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"}<br> [SP 800-73-5 Pt 2](https://csrc.nist.gov/pubs/sp/800/73/pt2/5/final){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"}<br> [SP 800-73-5 Part 3](https://csrc.nist.gov/pubs/sp/800/73/pt3/5/final){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"}  | Updated |
 | [SP 800-78-5](https://csrc.nist.gov/pubs/sp/800/78/5/final){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"}  | Updated |
 

--- a/_university/ficampolicymatrix.md
+++ b/_university/ficampolicymatrix.md
@@ -431,7 +431,7 @@ Some of the documents referenced in this matrix are managed by other agencies an
 | [SP 800-63A-4](https://csrc.nist.gov/pubs/sp/800/63/a/4/2pd){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"} | Updated |
 | [SP 800-63B-4](https://csrc.nist.gov/pubs/sp/800/63/b/4/2pd){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"} | Updated |	
 | [SP 800-63C-4](https://csrc.nist.gov/pubs/sp/800/63/c/4/2pd){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"} | Updated |
-| [SP 800-73-5 Pt 1](https://csrc.nist.gov/pubs/sp/800/73/pt1/5/final){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"}<br> [SP 800-73-5 Pt 2](https://csrc.nist.gov/pubs/sp/800/73/pt2/5/final){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"}<br> [SP 800-73-5 Part 3](https://csrc.nist.gov/pubs/sp/800/73/pt3/5/final){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"}  |
+| [SP 800-73-5 Pt 1](https://csrc.nist.gov/pubs/sp/800/73/pt1/5/final){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"}<br> [SP 800-73-5 Pt 2](https://csrc.nist.gov/pubs/sp/800/73/pt2/5/final){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"}<br> [SP 800-73-5 Part 3](https://csrc.nist.gov/pubs/sp/800/73/pt3/5/final){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"}  | Updated |
 | [SP 800-78-5](https://csrc.nist.gov/pubs/sp/800/78/5/final){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"}  | Updated |
 
 <br><br>

--- a/_university/ficampolicymatrix.md
+++ b/_university/ficampolicymatrix.md
@@ -426,13 +426,13 @@ Some of the documents referenced in this matrix are managed by other agencies an
 
 <hr>
 
-|  Name	     | 
-|:-----------|
-| [SP 800-63A-4](https://csrc.nist.gov/pubs/sp/800/63/a/4/2pd){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"} |
-| [SP 800-63B-4](https://csrc.nist.gov/pubs/sp/800/63/b/4/2pd){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"} |	
-| [SP 800-63C-4](https://csrc.nist.gov/pubs/sp/800/63/c/4/2pd){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"} |
+|  Name	     |  Status |
+|:-----------|----|
+| [SP 800-63A-4](https://csrc.nist.gov/pubs/sp/800/63/a/4/2pd){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"} | Updated |
+| [SP 800-63B-4](https://csrc.nist.gov/pubs/sp/800/63/b/4/2pd){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"} | Updated |	
+| [SP 800-63C-4](https://csrc.nist.gov/pubs/sp/800/63/c/4/2pd){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"} | Updated |
 | [SP 800-73-5 Pt 1](https://csrc.nist.gov/pubs/sp/800/73/pt1/5/final){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"}<br> [SP 800-73-5 Pt 2](https://csrc.nist.gov/pubs/sp/800/73/pt2/5/final){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"}<br> [SP 800-73-5 Part 3](https://csrc.nist.gov/pubs/sp/800/73/pt3/5/final){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"}  |
-| [SP 800-78-5](https://csrc.nist.gov/pubs/sp/800/78/5/final){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"}  |
+| [SP 800-78-5](https://csrc.nist.gov/pubs/sp/800/78/5/final){:target="_blank"}{:rel="noopener noreferrer"}{:class="usa-link usa-link--external"}  | Updated |
 
 <br><br>
 


### PR DESCRIPTION
## Updates: Policy Matrix Link Updates

- Updated links to policies on the [Policy Matrix Map](https://federalist-cf03235f-a054-4178-aafb-4e1e61e0d42c.sites.pages.cloud.gov/preview/gsa/idmanagement.gov/0507-idm-ficam-policy-matrix-update/university/policymap/) and [FICAM Policy Matrix](https://federalist-cf03235f-a054-4178-aafb-4e1e61e0d42c.sites.pages.cloud.gov/preview/gsa/idmanagement.gov/0507-idm-ficam-policy-matrix-update/university/policymatrix/) listing page. 
- Linked to PDFs where a PDF was present.
- Linked to the policy webpage where multiple parts of the same policy existed, since the webpage contained links to PDF's for all parts. 
- Updated descriptions and titles where needed to reflect correct version of polices.
- Relinked 404 not found link after using search on their website to locate missing policy. 
- Updated [Upcoming Documents and Revisions](https://federalist-cf03235f-a054-4178-aafb-4e1e61e0d42c.sites.pages.cloud.gov/preview/gsa/idmanagement.gov/0507-idm-ficam-policy-matrix-update/university/policymatrix/#upcoming-documents-and-revisions) section. 

@SuGhadiali 

📅 05/08/2025 