### PR TITLE
Potential fix for code scanning alert no. 4: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/uswds.js
+++ b/assets/js/uswds.js
@@ -4484,8 +4484,10 @@ function toggleHtmlTag(isMobile) {
   const primaryLinks = bigFooter.querySelectorAll(BUTTON);
   primaryLinks.forEach(currentElement => {
     const currentElementClasses = currentElement.getAttribute("class");
-    const preservedHtmlTag = currentElement.getAttribute("data-tag") || currentElement.tagName;
-    const newElementType = isMobile ? "button" : preservedHtmlTag;
+    const allowedTags = ["h4", "button"]; // Whitelist of allowed tags
+    const preservedHtmlTag = currentElement.getAttribute("data-tag");
+    const sanitizedTag = allowedTags.includes(preservedHtmlTag) ? preservedHtmlTag : "button";
+    const newElementType = isMobile ? "button" : sanitizedTag;
 
     // Create the new element
     const newElement = document.createElement(newElementType);


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/idmanagement.gov/security/code-scanning/4](https://github.com/GSA/idmanagement.gov/security/code-scanning/4)

To fix the issue, we need to ensure that the value of `newElementType` is sanitized and restricted to a predefined set of safe HTML tags. This can be achieved by validating the `data-tag` attribute against a whitelist of allowed tags (e.g., `['h4', 'button']`). If the value is not in the whitelist, we should default to a safe fallback value (e.g., `button`).

The changes will involve:
1. Defining a whitelist of allowed HTML tags.
2. Validating the `data-tag` attribute value against this whitelist.
3. Using a safe fallback value if the validation fails.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
