### PR TITLE
Updated USWDS to 3.13.0 from 3.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "pa11y-ci:sitemap": "pa11y-ci --sitemap http://localhost:4000/sitemap.xml --sitemap-exclude \"/*.pdf\""
   },
   "dependencies": {
-    "@uswds/uswds": "3.12.0"
+    "@uswds/uswds": "3.13.0"
   },
   "devDependencies": {
     "pa11y-ci": "^2.4.0",


### PR DESCRIPTION
## Update USWDS to 3.13.0

- updated USWDS to v3.13.0 from v3.12.0
- [Release Notes for 3.13.0](https://github.com/uswds/uswds/releases/tag/v3.13.0)

📅 06/26/2025