### PR TITLE
Removes Shutdown Banner from IDM

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -50,10 +50,3 @@ This appears at the top of the page letting the user know it's an official gover
   </div>
   <div class="usa-overlay"></div>
 </div>
-<div class="usa-alert usa-alert--warning">
-  <div class="usa-alert__body">
-    <h4 class="usa-alert__heading"></h4>
-    <p class="usa-alert__text">As a result of a temporary government shutdown, portions of this website are not being updated at this time. For more information on GSA’s shutdown procedures, please go to <a href="https://www.gsa.gov/directives-library/operations-in-the-absence-of-appropriations-14" target="_blank">https://www.gsa.gov/directives-library/operations-in-the-absence-of-appropriations-14</a>
-    </p>
-  </div>
-</div>


### PR DESCRIPTION
## Update: Removal of Shutdown Banner from IDM

- This PR removes the shutdown banner from the IDM site.

> Note: For post shutdown push only. 

@JBPayne007 

📅 11/12/2025 👍 😃 ☕ 
