### PR TITLE
updated guide urls and file name suffixes to GSA from Unifyia

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -92,7 +92,7 @@ primary_navigation:
       - name: Okta Yubikey Implementation Guide
         url: /implement/yubikey-guide/
       - name: GSA Implementation Guide for Passkeys (FIDO2)
-        url: /implement/unifyia-guide/
+        url: /implement/gsa-guide/
   - name: Functions
     children: 
       - name: FICAM Program
@@ -144,9 +144,9 @@ primary_navigation:
       - name: PIAM Process
         url: /experiments/pid/process/
       - name: Mobile PIV (mPIV) Experiment
-        url: /experiments/unifyia-mpiv-experiment/
+        url: /experiments/gsa-mpiv-experiment/
       - name: Shatterproof Digital Identity - GSA PQC Experiment
-        url: /experiments/unifyia-pqc-experiment/
+        url: /experiments/gsa-pqc-experiment/
         
 secondary_navigation:
   - name: Contact Us

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -23,9 +23,9 @@ partners:
   - text: ICAM FIBF For Comment
     href: /icam-fibf/
   - text: Mobile PIV (mPIV) Experiment
-    href: /experiments/unifyia-mpiv-experiment/
+    href: /experiments/gas-mpiv-experiment/
   - text: Shatterproof Digital Identity - GSA PQC Experiment
-    href: /experiments/unifyia-pqc-experiment/
+    href: /experiments/gsa-pqc-experiment/
 
 
 implement:
@@ -56,7 +56,7 @@ implement:
   - text: Okta Yubikey Implementation Guide
     href: /implement/yubikey-guide/
   - text: GSA Implementation Guide for Passkeys (FIDO2)
-    href: /implement/unifyia-guide/
+    href: /implement/gsa-guide/
 
     
 functions:

--- a/_experiments/gas-mpiv-experiment.md
+++ b/_experiments/gas-mpiv-experiment.md
@@ -3,7 +3,7 @@ layout: page
 collection: experiments
 title: Mobile PIV (mPIV) Experiment
 type: Markdown
-permalink: /experiments/unifyia-mpiv-experiment/
+permalink: /experiments/gsa-mpiv-experiment/
 description: Mobile PIV (mPIV) Experiment
 sidenav: papers
 sticky_sidenav: true

--- a/_experiments/gsa-pqc-experiment.md
+++ b/_experiments/gsa-pqc-experiment.md
@@ -3,7 +3,7 @@ layout: page
 collection: experiments
 title: Shatterproof Digital Identity - GSA PQC Experiment
 type: Markdown
-permalink: /experiments/unifyia-pqc-experiment/
+permalink: /experiments/gsa-pqc-experiment/
 description: Shatterproof Digital Identity - GSA PQC Experiment
 sidenav:  papers
 sticky_sidenav: true

--- a/_implement/gsa-guide.md
+++ b/_implement/gsa-guide.md
@@ -3,7 +3,7 @@ layout: page
 collection: implement
 title: FIDO2.1 Implementation using the Unifyia Platform - Initial Release
 type: Markdown
-permalink: /implement/unifyia-guide/
+permalink: /implement/gsa-guide/
 description: FIDO2.1 Implementation using the Unifyia Platform
 sidenav: implement
 sticky_sidenav: true


### PR DESCRIPTION
## Updates:  Changed URL and filename suffixes from `unifyia` to `gsa` 

[PREVIEW](https://federalist-cf03235f-a054-4178-aafb-4e1e61e0d42c.sites.pages.cloud.gov/preview/gsa/idmanagement.gov/0305-idm-wkly-updates/)

- updated permalinks for each guilde (3)
- updated url suffixes for guides in Implements and Experiments main menu dropdown.
- updated url suffixes for guides in Implements and Experiments sidenav.
  - from `/implement/unifyia-guide/`  to `/implement/gsa-guide/`
  - from  `/experiments/unifyia-mpiv-experiment/` to `/experiments/gsa-mpiv-experiment/`
  - from `/experiments/unifyia-pqc-experiment/` to `/experiments/gsa-pqc-experiment/` 
- Updated file name suffixes to `gsa` for 3 guildes: (this only renamed the `.md` file, no navigation affected)
  - `_experiments/gas-mpiv-experiment.md`
  - `_experiments/gsa-pqc-experiment.md`
  - `_implement/gsa-guide.md` 

📅 03/05/2026

