### PR TITLE
Production Update 0702

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GEM
     base64 (0.3.0)
     bigdecimal (3.2.2)
     colorator (1.1.0)
-    concurrent-ruby (1.3.5)
+    concurrent-ruby (1.3.7)
     csv (3.3.5)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)

--- a/_data/fpkinotifications.yml
+++ b/_data/fpkinotifications.yml
@@ -32,6 +32,21 @@
 # ee_ocsp_uri:
 #
 
+- notice_date: June 29, 2026
+  change_type: Intent to Issue CA Certificate
+  system: FPKI Trust Infrastructure - Federal Common Policy CA G2
+  change_description: The Federal Common Policy CA G2 intends to issue a new certificate to Entrust Managed Services Root CA between 7/10/2026 and 7/16/2023.
+  contact: fpki dash help at gsa dot gov
+  ca_certificate_hash: TBD
+  ca_certificate_issuer: CN=Federal Common Policy CA G2, OU=FPKI, O=U.S. Government, C=US
+  ca_certificate_subject: OU=Entrust Managed Services Root CA, OU=Certification Authorities, O=Entrust, C=US
+  cdp_uri: http://repo.fpki.gov/fcpca/fcpcag2.crl
+  aia_uri: http://repo.fpki.gov/fcpca/caCertsIssuedTofcpcag2.p7c
+  sia_uri: http://rootweb.managed.entrust.com/SIA/CertsIssuedByEMSRootCA.p7c
+  ocsp_uri: N/A
+  ee_cdp_uri: N/A
+  ee_ocsp_uri: N/A
+
 - notice_date: June 18, 2026
   change_type: Intent to Issue CA Certificate
   system: Entrust PKI SSP

--- a/_data/fpkinotifications.yml
+++ b/_data/fpkinotifications.yml
@@ -32,6 +32,21 @@
 # ee_ocsp_uri:
 #
 
+- notice_date: July 2, 2026
+  change_type: CA Certificate Issuance
+  system: FPKI Trust Infrastructure - Federal Bridge CA G4
+  change_description: The Federal Bridge CA G4 has issued a new certificate to the XTec NFI SSP Root CA 1 with validity dates of 6/29/2026 to 6/29/2029. 
+  contact:  fpki dash help at gsa dot gov
+  ca_certificate_hash: f34f74751b21b812b4392d126db6be96891c433b
+  ca_certificate_issuer: CN=Federal Bridge CA G4, OU=FPKI, O=U.S. Government, C=US
+  ca_certificate_subject: CN=XTec NFI SSP Root CA 1, OU=Certification Authorities, O=XTec Incorporated, C=US 
+  cdp_uri: http://repo.fpki.gov/bridge/fbcag4.crl
+  aia_uri: http://repo.fpki.gov/bridge/caCertsIssuedTofbcag4.p7c
+  sia_uri: http://aia.xca.xpki.com/AIA/IssuedCertsByXTec_NFI_SSP_Root_CA_1.p7c
+  ocsp_uri: N/A
+  ee_cdp_uri: N/A
+  ee_ocsp_uri: N/A
+
 - notice_date: June 29, 2026
   change_type: Intent to Issue CA Certificate
   system: FPKI Trust Infrastructure - Federal Common Policy CA G2

--- a/_implement/fpki_notifications.md
+++ b/_implement/fpki_notifications.md
@@ -74,7 +74,7 @@ These announcements and hot topics concern Federal Public Key Infrastructure cha
 <script type="text/javascript" src="{{ site.baseurl }}/assets/js/gexfjs.js"></script>
 <script type="text/javascript" src="{{ site.baseurl }}/assets/js/config.js"></script>
 
-**Last Update**: June 22, 2026
+**Last Update**: June 29, 2026
 
 {% include graph.html %}
 

--- a/_implement/tools/fpki-certs.gexf
+++ b/_implement/tools/fpki-certs.gexf
@@ -1,8 +1,8 @@
 <?xml version="1.0" ?>
 <gexf xmlns="http://gexf.net/1.3" xmlns:viz="http://gexf.net/1.3/viz" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://gexf.net/1.3 http://gexf.net/1.3/gexf.xsd" version="1.3">
-    <meta lastmodifieddate="2026-06-22">
+    <meta lastmodifieddate="2026-06-29">
         <creator>py-crawler</creator>
-        <description>Created by Py-Crawler on 2026-06-22</description>
+        <description>Created by Py-Crawler on 2026-06-29</description>
     </meta>
     <graph defaultedgetype="directed" mode="static">
         <nodes>


### PR DESCRIPTION
- Bump Ruby from 1.3.5 to 1.3.7 in bundler group #1940 
- Sync Dev 2 with staging #1941 
- Sync Main Dev with Staging #1942 
- Sync FICAM ARCH Demo with staginf #1943 
- Merging Dev 2 into Demo site #1944 
- Crawler Update #1946 
- FCPCA G2 - Entrust Managed Services Root CA #1948 
- Dev Sync - FICAM Dev 2 into Main FICAM Dev #1950 
- XTec NFI CA cert notice #1952  