### PR TITLE
0731 fpki notice cite update

### DIFF
--- a/_data/fpkinotifications.yml
+++ b/_data/fpkinotifications.yml
@@ -31,6 +31,21 @@
 # ee_cdp_uri:
 # ee_ocsp_uri:
 #
+- notice_date: July 30, 2026
+  change_type: Certificate Interoperability Issue
+  system: Department of State PKI
+  change_description: an issue with a PIV authentication certificate profile issued from the US Department of State PIV CA3 may cause authentication errors on some relying party applications.  Specifically, the CRL DP field in affected subscriber certificates includes a CRL Issuer field that may prevent normal revocation checking in a small number of relying party applications.  DoS profiles have been updated and new certificates issued after July 29th should not be impacted.  Remediation of historical impacted subscriber certificates via reissuance is expected in the near term future.
+  contact: TBD
+  ca_certificate_hash: 9ad6a2c0822acd9ed041bcb566cf8a7a6e4736a4
+  ca_certificate_issuer: CN = U.S. Department of State AD Root CA, CN = AIA, CN = Public Key Services, CN = Services, CN = Configuration, DC = state, DC = sbu
+  ca_certificate_subject: OU = U.S. Department of State PIV CA3, OU = Certification Authorities, OU = PIV, OU = Department of State, O = U.S. Government, C = US
+  cdp_uri: http://crls.pki.state.gov/crls/DoSADPKIRootCA1.crl
+  aia_uri: http://crls.pki.state.gov/AIA/CertsIssuedToDoSADRootCA.p7c
+  sia_uri: N/A
+  ocsp_uri: N/A
+  ee_cdp_uri: http://crls.pki.state.gov/crls/DoSADPKIPIVCA3.crl 
+  ee_ocsp_uri: http://ocsp.pki.state.gov/OCSP/DoSOCSPResponder
+
 - notice_date: July 27, 2026
   change_type: CA Certificate Issuance
   system: CertiPath Bridge CA

--- a/_implement/fpki_tools_cite-guide.md
+++ b/_implement/fpki_tools_cite-guide.md
@@ -149,7 +149,7 @@ The FPKIMA has developed [draft Common PQC Certificate and CRL Profiles]({{site.
 | Test Partner CRLs | CRL URL |
 | ------------ | ----------- |
 | Treasury | http://devpki.treasury.gov/Dev_US_Treasury_Root_CA.crl |
-| DoD | http://crl.nit.disa.mil/crl/DODJITCINTEROPERABILITYROOTCA2.crl |
+| DoD | http://crl.nit.disa.mil/crl/DODJITCINTEROPERABILITYROOTCA2.crl http://crl.nit.disa.mil/crl/DODJITCINTEROPERABILITYROOTCA3.crl |
 | Entrust SSP | http://dsspweb.managed.entrust.com/CRLs/EMSDemoFRootCA2.crl | 
 | WidePoint SSP | http://testcrl-server.orc.com/CRLs/WPSSPIntTESTCA.crl |
 | WidePoint NFI | http://testcrl-server.orc.com/CRLs/WIDEPOINTTESTNFIROOT2.crl |
@@ -158,7 +158,7 @@ The FPKIMA has developed [draft Common PQC Certificate and CRL Profiles]({{site.
 | Test Partner CA p7cs | p7c URLs |
 | ------------ | ----------- |
 | Treasury | SIA:http://devpki.treasury.gov/devroot_sia.p7c AIA:http://devpki.treasury.gov/cacertsissuedtodevtrca.p7c |
-| DoD | SIA:http://crl.nit.disa.mil/issuedby/DODJITCINTEROPERABILITYROOTCA2_IB.p7c AIA:http://crl.nit.disa.mil/issuedto/DODJITCINTEROPERABILITYROOTCA2_IT.p7c |
+| DoD | SIA:http://crl.nit.disa.mil/issuedby/DODJITCINTEROPERABILITYROOTCA2_IB.p7c AIA:http://crl.nit.disa.mil/issuedto/DODJITCINTEROPERABILITYROOTCA2_IT.p7c SIA:http://crl.nit.disa.mil/issuedby/DODJITCINTEROPERABILITYROOTCA3_IB.p7c AIA:http://crl.nit.disa.mil/issuedto/DODJITCINTEROPERABILITYROOTCA3_IT.p7c |
 | Entrust SSP | SIA:http://dsspweb.managed.entrust.com/SIA/CAcertsIssuedByEMSDemoFRootCA.p7c AIA:http://dsspweb.managed.entrust.com/AIA/CertsIssuedToEMSDemoFRootCA.p7c |
 | WidePoint SSP | SIA:http://testcrl-server.orc.com/caCerts/caCertsIssuedByWPSSPIntTESTCA.p7c AIA:http://testcrl-server.orc.com/caCerts/caCertsIssuedToWPSSPIntTESTCA.p7c |
 | WidePoint NFI | SIA:http://testcrl-server.orc.com/caCerts/caCertsIssuedByWIDEPOINTTESTNFIROOT2.p7c AIA:http://testcrl-server.orc.com/caCerts/caCertsIssuedToWIDEPOINTTESTNFIROOT2.p7c |


### PR DESCRIPTION
This updates FPKI notifications with recent DoS interoperability issue due to PIV auth certificate profile and also includes updated DoD JITC test repo links for their IRCA3.

Closes #2005 
Closes #2006 