### PR TITLE
0818-idm-dira-playbook-removal

### DIFF
--- a/_data/playbooks.yml
+++ b/_data/playbooks.yml
@@ -5,7 +5,7 @@
 
 # This file drives the Playbooks listing on the PoC IDManagement.gov front page lower half.
 # - 05-15--2023: Added the 'header' property for the header graphic for each playbook. 
-#   
+# - 07-18-2024: Moved to webp for image optimization (thanks Google) - CJB 
 #
 # title: name of the playbook
 # type: type of data the playbook is presented example: PDF, Markdown, HTML, Word Document
@@ -15,8 +15,8 @@
 # target: _self (replaces page), _blank (opens in a new window)
 # external: yes or no, if yes: logic uses full url of this property, if no: uses internal relative url to domain name
 # Note: If external, the 'header' graphic will still expect a relative path to a graphic located in the assets folder
-#
-# Moved to webp for image optimization (thanks Google) on 07-18-2024 - CJB 
+
+# Important!!!: If you update a playbook, please update the `pubdate` in this YAML file.
 
 - title: Cloud Identity Playbook
   type: Webpage

--- a/_data/playbooks.yml
+++ b/_data/playbooks.yml
@@ -34,13 +34,14 @@
   header: "/assets/playbooks/headers/playbook_02.webp"
   target: _self
 
-- title: Digital Identity Risk Assessment Playbook
-  type: Webpage
-  pubdate: 2025-06
-  description: The Digital Identity Risk Assessment playbook is a six-step playbook for completing a digital identity risk assessment as described in OMB Memo 19-17 and NIST Special Publication 800-63-3.
-  url: "/playbooks/dira/"
-  header: "/assets/playbooks/headers/playbook_03.webp"
-  target: _self
+# Removal requested by Joe on 08/17/2026 - cjb
+# - title: Digital Identity Risk Assessment Playbook
+#   type: Webpage
+#   pubdate: 2025-06
+#   description: The Digital Identity Risk Assessment playbook is a six-step playbook for completing a digital identity risk assessment as described in OMB Memo 19-17 and NIST Special Publication 800-63-3.
+#   url: "/playbooks/dira/"
+#   header: "/assets/playbooks/headers/playbook_03.webp"
+#   target: _self
 
 - title: Digital Worker Identity Playbook
   type: Webpage


### PR DESCRIPTION
## Remove DIRA Playbook from IDM

Preview: [Homepage](https://federalist-cf03235f-a054-4178-aafb-4e1e61e0d42c.sites.pages.cloud.gov/preview/gsa/idmanagement.gov/0818-idm-dira-playbook-removal/)
Preview: [Playbook Listing](https://federalist-cf03235f-a054-4178-aafb-4e1e61e0d42c.sites.pages.cloud.gov/preview/gsa/idmanagement.gov/0818-idm-dira-playbook-removal/playbooks/)

> Display of the Playbooks is driven by the  `_data/playbooks.yml` file, entries in this file control display of the playbook listings for both the homepage and the `/playbooks/` listing. Removal of a playbook entry in this file, removes the playbook entry from both pages on IDM. 

- Commented out DIRA Playbook in `_data/playbooks.yml` YAML file. 
- Added comment to remind us to update the `pubdate` in the `_data/playbooks.yml` for a playbook when it is updated or changed. 

📅 08/18/2026

@BenSaxton 